### PR TITLE
Continuous integration with Travis & Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+    - "3.6"
+
+install: "make"
+
+script:
+    - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ python:
 install: "make"
 
 script:
-    - make test
+    - make ci
+
+after_success:
+    - make coverage

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+init:
+	pip install pipenv
+	pipenv install --dev --ignore-pipfile
+
+test:
+	pipenv run pytest

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,10 @@ init:
 	pipenv install --dev --ignore-pipfile
 
 test:
-	pipenv run pytest
+	pipenv run pytest --cov=mentorship --pep8
+
+ci:
+	pipenv run pytest --pep8 mentorship --cov=mentorship --cov-report term --cov-report html
+
+coverage:
+	pipenv run coveralls

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ init:
 	pipenv install --dev --ignore-pipfile
 
 test:
-	pipenv run pytest --cov=mentorship --pep8
+	pipenv run pytest --cov=mentorship --pep8 --cov-branch
 
 ci:
-	pipenv run pytest --pep8 mentorship --cov=mentorship --cov-report term --cov-report html
+	pipenv run pytest --pep8 mentorship --cov=mentorship --cov-report term --cov-report html --cov-branch
 
 coverage:
 	pipenv run coveralls

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,10 @@ verify_ssl = true
 [dev-packages]
 pytest = "*"
 pytest-django = "*"
+coverage = "*"
+pytest-cov = "*"
+pytest-pep8 = "*"
+python-coveralls = "*"
 
 [packages]
 Django = "<2.0,>1.11"

--- a/Pipfile
+++ b/Pipfile
@@ -2,6 +2,10 @@
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 
+[dev-packages]
+pytest = "*"
+pytest-django = "*"
+
 [packages]
 Django = "<2.0,>1.11"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d74ff0acf34454752c0d9e7a632591b5eeb1ee561da13e7e110fb1eceab0fa02"
+            "sha256": "a6866d50d483caf9fe40d9c2140b7c4545b8a59b66df0bb851820e88f78c2328"
         },
         "requires": {
             "python_version": "3.6"
@@ -22,8 +22,29 @@
         }
     },
     "develop": {
+        "apipkg": {
+            "version": "==1.4"
+        },
         "attrs": {
             "version": "==17.3.0"
+        },
+        "certifi": {
+            "version": "==2017.11.5"
+        },
+        "chardet": {
+            "version": "==3.0.4"
+        },
+        "coverage": {
+            "version": "==4.4.2"
+        },
+        "execnet": {
+            "version": "==1.5.0"
+        },
+        "idna": {
+            "version": "==2.6"
+        },
+        "pep8": {
+            "version": "==1.7.1"
         },
         "pluggy": {
             "version": "==0.6.0"
@@ -34,14 +55,35 @@
         "pytest": {
             "version": "==3.3.0"
         },
+        "pytest-cache": {
+            "version": "==1.0"
+        },
+        "pytest-cov": {
+            "version": "==2.5.1"
+        },
         "pytest-django": {
             "version": "==3.1.2"
+        },
+        "pytest-pep8": {
+            "version": "==1.0.6"
+        },
+        "python-coveralls": {
+            "version": "==2.9.1"
+        },
+        "pyyaml": {
+            "version": "==3.12"
+        },
+        "requests": {
+            "version": "==2.18.4"
         },
         "setuptools": {
             "version": "==38.2.3"
         },
         "six": {
             "version": "==1.11.0"
+        },
+        "urllib3": {
+            "version": "==1.22"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0bbef8f9be04328c75980a982c376ed6fadb99a569fe681ae15d3e7b3beeed6b"
+            "sha256": "d74ff0acf34454752c0d9e7a632591b5eeb1ee561da13e7e110fb1eceab0fa02"
         },
         "requires": {
             "python_version": "3.6"
@@ -21,5 +21,27 @@
             "version": "==2017.3"
         }
     },
-    "develop": {}
+    "develop": {
+        "attrs": {
+            "version": "==17.3.0"
+        },
+        "pluggy": {
+            "version": "==0.6.0"
+        },
+        "py": {
+            "version": "==1.5.2"
+        },
+        "pytest": {
+            "version": "==3.3.0"
+        },
+        "pytest-django": {
+            "version": "==3.1.2"
+        },
+        "setuptools": {
+            "version": "==38.2.3"
+        },
+        "six": {
+            "version": "==1.11.0"
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ part those should be "the right thing".
 
 ## Testing
 
-To run the tests, use pytest, such as with `pipenv run pytest`. This will run
-all tests written in typical Django style, as well as all other tests. For
-info on running pytest-style Django tests, see
+To run the tests, run `make test` (no pipenv). This will run `pytest` with
+coverage, including all tests written in typical Django style, as well as all
+other tests. For info on writing pytest-style Django tests, see
 https://pytest-django.readthedocs.io/en/latest/tutorial.html .

--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ any new packages. It is safe to run this if you have not installed anything
 
 Commit any changes that occur for `Pipfile` and `Pipfile.lock`. For the most
 part those should be "the right thing".
+
+## Testing
+
+To run the tests, use pytest, such as with `pipenv run pytest`. This will run
+all tests written in typical Django style, as well as all other tests. For
+info on running pytest-style Django tests, see
+https://pytest-django.readthedocs.io/en/latest/tutorial.html .

--- a/mentorship/settings.py
+++ b/mentorship/settings.py
@@ -86,16 +86,20 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        'NAME': 'django.contrib.auth.password_validation.'
+                'UserAttributeSimilarityValidator',
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'NAME': 'django.contrib.auth.password_validation.'
+                'MinimumLengthValidator',
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        'NAME': 'django.contrib.auth.password_validation.'
+                'CommonPasswordValidator',
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        'NAME': 'django.contrib.auth.password_validation.'
+                'NumericPasswordValidator',
     },
 ]
 

--- a/mentorship/tests/test_smoke.py
+++ b/mentorship/tests/test_smoke.py
@@ -1,0 +1,4 @@
+
+
+def test_smoke():
+    assert True, "Not true"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = mentorship.settings
+python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
This PR includes Continuous Integration support for Travis & Coveralls. Right now those will not happen automatically on the main repository because that needs to be set up in both with the PuPPy github login. Setting them up only requires logging into each tool and then adding this particular repo; the config files take care of the rest. Both tools are free for open source. I recommend we set them up before merging this.

- [ ] PuPPy https://travis-ci.org setup
- [ ] PuPPy https://coveralls.io setup

You can still see what the test runs look like before those are done, as I've set them both up for my fork alone.

- https://travis-ci.org/fugu13/mentorship-app
- https://coveralls.io/github/fugu13/mentorship-app

This PR also includes pytest (with Django testing support) and a single smoke test (`assert True`). pep8 checking is turned on.