### PR TITLE
Rename the login api url to "login_api"

### DIFF
--- a/mentorship/urls.py
+++ b/mentorship/urls.py
@@ -55,6 +55,6 @@ urlpatterns = [
     url(r'^pairing/(?P<pairing_id>[0-9]+)/rejected/$', pairing_views.pairing_rejected_view, name="pairing_rejected"),
     url(r'^pairing/request/(?P<mentee_id>[0-9]+)/(?P<mentor_id>[0-9]+)/$', pairing_views.pairing_request_view, name="pairing_request"),
     url(r'^api/v1/helloworld/$', api_views.hello_world, name="hello_world_api"),  # this route returns a message of Hello World!
-    url(r'^api/v1/login/$', api_views.login, name="login"),
+    url(r'^api/v1/login/$', api_views.login, name="login_api"),
     url(r'^api/v1/', include('rest_framework.urls'), name="rest_api"),  # API login and logout
 ]


### PR DESCRIPTION
> Naming it "login" was causing the Login button to make a direct get
> request to the login api, rather than rendering the login page

Still getting familiar with the repository, so decided not to get too ambitious with my first commit. Found what I think is a bug with the Login link.
