### PR TITLE
Add api for getting user data (User, Profile, Mentor, Mentee)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ include =
 	mentorship/*
 	mentorship_profile/*
 	mentorship_pairing/*
+	mentorship_api/*
 
 [report]
 omit = 

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ init:
 	pipenv install --dev --ignore-pipfile
 
 test:
-	pipenv run pytest --cov=mentorship --cov=mentorship_profile --cov=mentorship_pairing --pep8 --cov-branch --cov-report term-missing
+	pipenv run pytest --cov=mentorship --cov=mentorship_profile --cov=mentorship_pairing --cov=mentorship_api --pep8 --cov-branch --cov-report term-missing
 
 ci:
-	pipenv run pytest --pep8 --cov=mentorship --cov=mentorship_profile --cov=mentorship_pairing --cov-report term --cov-report html --cov-branch
+	pipenv run pytest --pep8 --cov=mentorship --cov=mentorship_profile --cov=mentorship_pairing --cov=mentorship_api --cov-report term --cov-report html --cov-branch
 
 coverage:
 	pipenv run coveralls

--- a/mentorship/settings.py
+++ b/mentorship/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'mentorship_profile',
     'mentorship_pairing',
     'mentorship_notification',
+    'mentorship_api',
     'rest_framework',
     'rest_framework_jwt',
     'multiselectfield',

--- a/mentorship/urls.py
+++ b/mentorship/urls.py
@@ -55,8 +55,8 @@ urlpatterns = [
     url(r'^pairing/(?P<pairing_id>[0-9]+)/accepted/$', pairing_views.pairing_accepted_view, name="pairing_accepted"),
     url(r'^pairing/(?P<pairing_id>[0-9]+)/rejected/$', pairing_views.pairing_rejected_view, name="pairing_rejected"),
     url(r'^pairing/request/(?P<mentee_id>[0-9]+)/(?P<mentor_id>[0-9]+)/$', pairing_views.pairing_request_view, name="pairing_request"),
-    url(r'^api/v1/helloworld/$', api_views.hello_world, name="hello_world_api"),  # this route returns a message of Hello World!
     url(r'^api/v1/token-auth/$', obtain_jwt_token, name="token_auth_api"),
     url(r'^api/v1/token-refresh/$', refresh_jwt_token, name="token_refresh_api"),
+    url(r'^api/v1/user/$', api_views.UserDetail.as_view(), name="user_api"),
     url(r'^api/v1/', include('rest_framework.urls'), name="rest_api"),  # API login and logout
 ]

--- a/mentorship_api/admin.py
+++ b/mentorship_api/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/mentorship_api/models.py
+++ b/mentorship_api/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/mentorship_api/serializers.py
+++ b/mentorship_api/serializers.py
@@ -1,0 +1,40 @@
+from rest_framework import serializers
+from django.contrib.auth.models import User
+
+from mentorship_profile.models import Profile, Mentor, Mentee
+
+
+class MentorSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Mentor
+        fields = ("id", "mentor_status", "areas_of_interest",
+                  "approved_mentors",
+                  "available_mentors", "pending_mentors", "mentee_capacity",
+                  "pending_mentors", "mentee_capacity",
+                  "currently_accepting_mentees")
+
+
+class MenteeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Mentee
+        fields = ("id", "area_of_interest", "goals")
+
+
+class ProfileSerializer(serializers.ModelSerializer):
+    mentor = MentorSerializer()
+    mentee = MenteeSerializer()
+
+    class Meta:
+        model = Profile
+        fields = ("id", "slack_handle", "linked_in_url", "projects_url", "bio",
+                  "years_industry_experience", "email_confirmed",
+                  "mentor", "mentee")
+
+
+class UserSerializer(serializers.ModelSerializer):
+    profile = ProfileSerializer()
+
+    class Meta:
+        model = User
+        fields = ("id", "username", "email", "first_name", "last_name",
+                  "profile")

--- a/mentorship_api/tests.py
+++ b/mentorship_api/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/mentorship_api/tests/test_GetProfile.py
+++ b/mentorship_api/tests/test_GetProfile.py
@@ -1,0 +1,106 @@
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from mentorship_profile.models import Profile, Mentor, Mentee
+
+
+class GetProfile(APITestCase):
+    def setUp(self):
+        password = "testtest123"
+        self.user = User.objects.create_user(username="api-tester",
+                                             password=password,
+                                             first_name="Johnny",
+                                             last_name="O'Donnell",
+                                             email="test@test.test")
+
+        self.user.profile = Profile(id=self.user.profile.id,
+                                    slack_handle="johnnyodonnell",
+                                    linked_in_url="reidhoffman",
+                                    projects_url="github.com/johnnyodonnell",
+                                    bio="I am a test profile",
+                                    years_industry_experience="1-2")
+        self.user.profile.save()
+
+        url = reverse("token_auth_api")
+        response = self.client.post(url, {
+            "username": self.user.username,
+            "password": password,
+        })
+        token = response.json()["token"]
+        self.client.credentials(HTTP_AUTHORIZATION="JWT " + token)
+
+    def test_get_profile(self):
+        url = reverse("user_api")
+        response = self.client.get(url)
+        data = response.json()
+        self.assertTrue(data)
+        self.assertEqual(data["username"], self.user.username)
+        self.assertEqual(data["first_name"], self.user.first_name)
+        self.assertEqual(data["last_name"], self.user.last_name)
+        self.assertEqual(data["email"], self.user.email)
+
+        self.assertTrue(data["profile"])
+        self.assertEqual(data["profile"]["id"], self.user.profile.id)
+        self.assertEqual(data["profile"]["slack_handle"],
+                         self.user.profile.slack_handle)
+        self.assertEqual(data["profile"]["linked_in_url"],
+                         self.user.profile.linked_in_url)
+        self.assertEqual(data["profile"]["projects_url"],
+                         self.user.profile.projects_url)
+        self.assertEqual(data["profile"]["bio"], self.user.profile.bio)
+        self.assertEqual(data["profile"]["years_industry_experience"],
+                         self.user.profile.years_industry_experience)
+
+    def test_get_mentor_and_mentee(self):
+        self.user.profile.mentor = Mentor(
+                mentor_status="approved",
+                areas_of_interest=["career_growth"],
+                mentee_capacity=3,
+                currently_accepting_mentees=True,
+                profile=self.user.profile)
+        self.user.profile.mentor.save()
+
+        self.user.profile.mentee = Mentee(
+                area_of_interest="career_growth",
+                goals="increase test coverage",
+                profile=self.user.profile)
+        self.user.profile.mentee.save()
+
+        url = reverse("user_api")
+        response = self.client.get(url)
+        data = response.json()
+        self.assertTrue(data)
+        self.assertEqual(data["username"], self.user.username)
+        self.assertEqual(data["first_name"], self.user.first_name)
+        self.assertEqual(data["last_name"], self.user.last_name)
+        self.assertEqual(data["email"], self.user.email)
+
+        self.assertTrue(data["profile"])
+        self.assertEqual(data["profile"]["id"], self.user.profile.id)
+        self.assertEqual(data["profile"]["slack_handle"],
+                         self.user.profile.slack_handle)
+        self.assertEqual(data["profile"]["linked_in_url"],
+                         self.user.profile.linked_in_url)
+        self.assertEqual(data["profile"]["projects_url"],
+                         self.user.profile.projects_url)
+        self.assertEqual(data["profile"]["bio"], self.user.profile.bio)
+        self.assertEqual(data["profile"]["years_industry_experience"],
+                         self.user.profile.years_industry_experience)
+
+        self.assertTrue(data["profile"]["mentor"])
+        self.assertEqual(data["profile"]["mentor"]["mentor_status"],
+                         self.user.profile.mentor.mentor_status)
+        self.assertEqual(data["profile"]["mentor"]["areas_of_interest"],
+                         self.user.profile.mentor.areas_of_interest)
+        self.assertEqual(data["profile"]["mentor"]["mentee_capacity"],
+                         self.user.profile.mentor.mentee_capacity)
+        self.assertEqual(
+                data["profile"]["mentor"]["currently_accepting_mentees"],
+                self.user.profile.mentor.currently_accepting_mentees)
+
+        self.assertTrue(data["profile"]["mentee"])
+        self.assertEqual(data["profile"]["mentee"]["area_of_interest"],
+                         self.user.profile.mentee.area_of_interest)
+        self.assertEqual(data["profile"]["mentee"]["goals"],
+                         self.user.profile.mentee.goals)

--- a/mentorship_api/views.py
+++ b/mentorship_api/views.py
@@ -1,8 +1,21 @@
-from rest_framework.decorators import api_view
+from rest_framework.views import APIView
 from rest_framework.response import Response
+from django.contrib.auth.models import User
+
+from mentorship_profile.models import Profile, Mentor, Mentee
+from mentorship_api.serializers import UserSerializer
 
 
-@api_view()
-def hello_world(request):
-    """Get for the hello world test."""
-    return Response({'message': 'Hello World!'})
+class UserDetail(APIView):
+    def get(self, request, format=None):
+        user = request.user
+        user.profile = Profile.objects.get(pk=user.profile.id)
+
+        if (user.profile.is_mentor()):
+            user.profile.mentor = Mentor.objects.get(pk=user.profile.mentor.id)
+
+        if (user.profile.is_mentee()):
+            user.profile.mentee = Mentee.objects.get(pk=user.profile.mentee.id)
+
+        userSerializer = UserSerializer(user)
+        return Response(userSerializer.data)


### PR DESCRIPTION
Adding API for getting user data

This will return data that looks like the following:
```
{  
   'id':1,
   'username':'api-tester',
   'email':'test@test.test',
   'first_name':'Johnny',
   'last_name':"O'Donnell",
   'profile':{  
      'id':1,
      'slack_handle':'johnnyodonnell',
      'linked_in_url':'reidhoffman',
      'projects_url':'github.com/johnnyodonnell',
      'bio':'I am a test profile',
      'years_industry_experience':'1-2',
      'email_confirmed':False,
      'mentor':{  
         'id':1,
         'mentor_status':'approved',
         'areas_of_interest':[  
            'career_growth'
         ],
         'mentee_capacity':3,
         'currently_accepting_mentees':True
      },
      'mentee':{  
         'id':1,
         'area_of_interest':'career_growth',
         'goals':'increase test coverage'
      }
   }
}
```