### PR TITLE
React Mentor/Mentee Registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "superagent": "3.8.3"
   },
   "devDependencies": {
+    "enzyme": "3.5.0",
+    "enzyme-adapter-react-16": "1.3.1",
     "eslint": "4.19.1",
     "eslint-config-prettier": "2.9.0",
     "eslint-config-react-app": "2.1.0",
@@ -34,7 +36,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
+    "test": "react-scripts test --env=jsdom --setupFiles ./test-setup.js",
     "lint": "eslint ./src --max-warnings 0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@material-ui/core": "^1.5.0",
     "jwt-decode": "^2.2.0",
     "react": "16.4.1",
     "react-dom": "16.4.1",
@@ -24,7 +25,7 @@
     "eslint-config-react-app": "2.1.0",
     "eslint-plugin-flowtype": "2.50.0",
     "eslint-plugin-import": "2.13.0",
-    "eslint-plugin-jsx-a11y": "6.1.1",
+    "eslint-plugin-jsx-a11y": "5.1.1",
     "eslint-plugin-prettier": "2.6.2",
     "eslint-plugin-react": "7.10.0",
     "prettier": "1.13.7"
@@ -37,7 +38,7 @@
     "lint": "eslint ./src --max-warnings 0"
   },
   "engines": {
-    "node": ">8.9.4",
+    "node": ">8.9.3",
     "npm": "5.6.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@material-ui/core": "^1.5.0",
+    "@material-ui/core": "3.0.1",
     "jwt-decode": "^2.2.0",
     "react": "16.4.1",
     "react-dom": "16.4.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "reactstrap": "^6.4.0",
     "redux": "^4.0.0",
     "redux-api-middleware": "^2.3.0",
+    "redux-form": "7.4.2",
     "redux-persist": "^5.10.0",
     "redux-persist-transform-filter": "0.0.18",
     "redux-thunk": "^2.3.0",
@@ -34,7 +35,6 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "postinstall": "npm run build",
     "lint": "eslint ./src --max-warnings 0"
   },
   "engines": {

--- a/src/App.js
+++ b/src/App.js
@@ -3,20 +3,19 @@ import { BrowserRouter } from 'react-router-dom';
 import Main from './Main/Main';
 import Header from './Main/Header';
 import { connect } from 'react-redux';
-import {echo} from './Main/actions/echo';
-import {serverMessage} from './Main/reducers';
+import { echo } from './Main/actions/echo';
+import { serverMessage } from './Main/reducers';
 
 class App extends Component {
-  
   componentDidMount() {
-    this.props.fetchMessage('Hi!')
-}
+    this.props.fetchMessage('Hi!');
+  }
 
   render() {
     return (
       <BrowserRouter>
         <div className="App">
-          <Header/>
+          <Header />
           <Main />
         </div>
       </BrowserRouter>

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { echo } from './Main/actions/echo';
 import { serverMessage } from './Main/reducers';
 
-class App extends Component {
+export class App extends Component {
   componentDidMount() {
     this.props.fetchMessage('Hi!');
   }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './App';
+import { App } from './App';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+  ReactDOM.render(<App fetchMessage={jest.fn()} />, div);
   ReactDOM.unmountComponentAtNode(div);
 });

--- a/src/Main/Header.js
+++ b/src/Main/Header.js
@@ -8,10 +8,13 @@ class Header extends Component {
         <nav>
           <ul>
             <li>
-              <Link to="/hello"> Hello Home</Link>
+              <Link to="/hello">Hello Home</Link>
             </li>
             <li>
-              <Link to="/Register/Register"> Register</Link>
+              <Link to="/Registration/Mentor">Mentor Registration</Link>
+            </li>
+            <li>
+              <Link to="/Registration/Mentee">Mentee Registration</Link>
             </li>
           </ul>
         </nav>

--- a/src/Main/Header.js
+++ b/src/Main/Header.js
@@ -1,19 +1,23 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 
-class Header extends Component{
-  render(){
-    return(
+class Header extends Component {
+  render() {
+    return (
       <header>
         <nav>
           <ul>
-            <li><Link to="/hello"> Hello Home</Link></li>
-            <li><Link to="/Register/Register"> Register</Link></li>
+            <li>
+              <Link to="/hello"> Hello Home</Link>
+            </li>
+            <li>
+              <Link to="/Register/Register"> Register</Link>
+            </li>
           </ul>
         </nav>
       </header>
-  );
-        }
+    );
+  }
 }
 
-export default Header
+export default Header;

--- a/src/Main/Login/LoginForm.js
+++ b/src/Main/Login/LoginForm.js
@@ -1,47 +1,60 @@
-import React, {Component} from 'react'
-import { Alert, Button, Jumbotron,  Form } from 'reactstrap';
+import React, { Component } from 'react';
+import { Alert, Button, Jumbotron, Form } from 'reactstrap';
 
-import TextInput from './TextInput'
+import TextInput from './TextInput';
 
 export default class LoginForm extends Component {
   state = {
     username: '',
-    password: ''
-  }
+    password: '',
+  };
 
-  handleInputChange = (event) => {
+  handleInputChange = event => {
     const target = event.target;
-    const value = target.type ===
-        'checkbox' ? target.checked : target.value;
+    const value = target.type === 'checkbox' ? target.checked : target.value;
     const name = target.name;
 
     this.setState({
-      [name]: value
+      [name]: value,
     });
-  }
+  };
 
   // componentDidMount() {
   //   this.primaryInput.focus();
   // }
 
-  onSubmit = (event) => {
-    event.preventDefault()
-    this.props.onSubmit(this.state.username, this.state.password)
-  }
+  onSubmit = event => {
+    event.preventDefault();
+    this.props.onSubmit(this.state.username, this.state.password);
+  };
 
   render() {
-    const errors = this.props.errors || {}
+    const errors = this.props.errors || {};
 
     return (
       <Jumbotron className="container">
         <Form onSubmit={this.onSubmit}>
           <h1>Authentication</h1>
-          {errors.non_field_errors?<Alert color="danger">{errors.non_field_errors}</Alert>:""}
-          <TextInput name="username" label="Username" error={errors.username} getRef={input => this.primaryInput = input} onChange={this.handleInputChange}/>
-          <TextInput name="password" label="Password" error={errors.password} type="password" onChange={this.handleInputChange}/>
-          <Button type="submit" color="primary" size="lg">Log In</Button>
+          {errors.non_field_errors ? <Alert color="danger">{errors.non_field_errors}</Alert> : ''}
+          <TextInput
+            name="username"
+            label="Username"
+            error={errors.username}
+            getRef={input => (this.primaryInput = input)}
+            onChange={this.handleInputChange}
+          />
+          <TextInput
+            name="password"
+            label="Password"
+            error={errors.password}
+            type="password"
+            onChange={this.handleInputChange}
+          />
+          <Button type="submit" color="primary" size="lg">
+            Log In
+          </Button>
         </Form>
       </Jumbotron>
-    )
+    );
   }
 }

--- a/src/Main/Login/TextInput.js
+++ b/src/Main/Login/TextInput.js
@@ -1,15 +1,21 @@
-import React from 'react'
+import React from 'react';
 import { FormGroup, FormFeedback, Label, Input } from 'reactstrap';
 
-export default ({name, label, error, type, ...rest}) => {
+export default ({ name, label, error, type, ...rest }) => {
   const id = `id_${name}`,
-        input_type = type?type:"text"
+    input_type = type ? type : 'text';
 
   return (
     <FormGroup>
-      { label?<Label htmlFor={id}>{label}</Label>: "" }
-      <Input type={input_type} name={name} id={id} className={error?"is-invalid":""} {...rest} />
-      { error? <FormFeedback className="invalid-feedback">{error}</FormFeedback>: "" }
+      {label ? <Label htmlFor={id}>{label}</Label> : ''}
+      <Input
+        type={input_type}
+        name={name}
+        id={id}
+        className={error ? 'is-invalid' : ''}
+        {...rest}
+      />
+      {error ? <FormFeedback className="invalid-feedback">{error}</FormFeedback> : ''}
     </FormGroup>
-  )
-}
+  );
+};

--- a/src/Main/Main.js
+++ b/src/Main/Main.js
@@ -2,7 +2,8 @@ import React, { Component } from 'react';
 import { Switch, Route, Redirect, withRouter } from 'react-router-dom';
 import Home from './Home/Home';
 import HelloWorld from './HelloWorld';
-import MentorRegisterContainer from './Register/MentorRegisterContainer';
+import MentorRegistrationContainer from './Register/MentorRegistrationContainer';
+import MenteeRegistrationContainer from './Register/MenteeRegistrationContainer';
 
 class Main extends Component {
   render() {
@@ -11,7 +12,8 @@ class Main extends Component {
         <Switch>
           <Route exact path="/hello" component={Home} />
           <Route path="/hello/helloworld" component={HelloWorld} />
-          <Route path="/Register/Register" component={MentorRegisterContainer} />
+          <Route path="/Registration/Mentor" component={MentorRegistrationContainer} />
+          <Route path="/Registration/Mentee" component={MenteeRegistrationContainer} />
           <Redirect to="/hello" />
         </Switch>
       </div>

--- a/src/Main/Main.js
+++ b/src/Main/Main.js
@@ -2,7 +2,8 @@ import React, { Component } from 'react';
 import { Switch, Route, Redirect, withRouter } from 'react-router-dom';
 import Home from './Home/Home';
 import HelloWorld from './HelloWorld';
-import Register from './Register/MentorRegister';
+import MentorRegisterContainer from './Register/MentorRegisterContainer';
+
 class Main extends Component {
   render() {
     return (
@@ -10,7 +11,7 @@ class Main extends Component {
         <Switch>
           <Route exact path="/hello" component={Home} />
           <Route path="/hello/helloworld" component={HelloWorld} />
-          <Route path="/Register/Register" component={Register} />
+          <Route path="/Register/Register" component={MentorRegisterContainer} />
           <Redirect to="/hello" />
         </Switch>
       </div>

--- a/src/Main/Main.js
+++ b/src/Main/Main.js
@@ -10,7 +10,7 @@ class Main extends Component {
         <Switch>
           <Route exact path="/hello" component={Home} />
           <Route path="/hello/helloworld" component={HelloWorld} />
-          <Route path ='/Register/Register' component={Register}/>
+          <Route path="/Register/Register" component={Register} />
           <Redirect to="/hello" />
         </Switch>
       </div>

--- a/src/Main/Register/MenteeRegistrationContainer.js
+++ b/src/Main/Register/MenteeRegistrationContainer.js
@@ -1,0 +1,13 @@
+import { reduxForm } from 'redux-form';
+
+import Registration from './Registration';
+import validate from './RegistrationValidation';
+
+export default reduxForm({
+  form: 'MenteeRegistration',
+  initialValues: { interests: [] },
+  validate,
+  onSubmit: () => {
+    console.log('here');
+  },
+})(Registration);

--- a/src/Main/Register/MentorRegister.js
+++ b/src/Main/Register/MentorRegister.js
@@ -1,10 +1,11 @@
-import React, { Component } from 'react';
-import "./MentorRegister.css"
+import React from 'react';
+import './MentorRegister.css';
+import TextField from '@material-ui/core/TextField';
 
 class MentorRegister extends React.Component {
-  constructor(props){
+  constructor(props) {
     super(props);
-    this.state ={
+    this.state = {
       username: '',
       firstname: '',
       lastname: '',
@@ -26,238 +27,215 @@ class MentorRegister extends React.Component {
     };
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
-
   }
 
-
-  handleChange(event){
-    {/* Handles Changes for all Values, checkbox, number, and text */}
+  handleChange(event) {
+    /* Handles Changes for all Values, checkbox, number, and text */
+    console.log(event.target);
     const target = event.target;
     const value = target.type === 'checkbox' ? target.checked : target.value;
     const name = target.name;
     console.log(value);
     this.setState({
-      [name]: value
+      [name]: value,
     });
   }
 
+  handleSubmit(event) {
+    /* Handles Submit when submit button is pressed */
 
-  handleSubmit(event){
-    {/* Handles Submit when submit button is pressed */}
-    {/* Super Agent should go here */}
-    alert('A name and age were submitted. \nName:  ' + this.state.portfolio + ' Age: ' + this.state.age);
+    /* Super Agent should go here */
+
+    alert(
+      'A name and age were submitted. \nName:  ' + this.state.portfolio + ' Age: ' + this.state.age
+    );
     console.log(this.state.age);
     event.preventDefault();
   }
 
-  checkPasswordMatch(){
-    {/*Handles password matching confirmation*/}
+  checkPasswordMatch() {
+    /* Handles password matching confirmation */
   }
 
-
-  render(){
-    return(
+  render() {
+    return (
       <div>
         <h1>Registration Page for Mentor</h1>
         <form onSubmit={this.handleSubmit}>
           <label for="pinfo">Personal Information</label>
-          <section id="pinfo"name="personalinfo">
+          <section id="pinfo" name="personalinfo">
+            <TextField name="firstname" label="First Name" onChange={this.handleChange} />
+            <TextField
+              name="lastname"
+              label="Last Name"
+              value={this.state.lastname}
+              onChange={this.handleChange}
+            />
+            <p />
+            <label for="lastname">LastName:</label>
+            <input
+              type="text"
+              name="lastname"
+              value={this.state.lastname}
+              onChange={this.handleChange}
+            />
 
-            <p></p>
-        <label for="firstname">FirstName:</label>
-          <input type="text"
-            name="firstname"
-            value={this.state.firstname}
-            onChange={this.handleChange}  />
+            <p />
+            <label for="username">Username: </label>
+            <input
+              type="text"
+              name="username"
+              value={this.state.username}
+              onChange={this.handleChange}
+            />
 
+            <p />
+            <label for="email"> Email: </label>
+            <input type="text" name="email" value={this.state.email} onChange={this.handleChange} />
 
-          <p></p>
-        <label for="lastname">LastName:</label>
-          <input
-            type="text"
-            name="lastname"
-            value={this.state.lastname}
-            onChange={this.handleChange}  />
+            <p />
+            <label for="age"> Age: </label>
+            <input
+              id="num"
+              type="number"
+              name="age"
+              value={this.state.age}
+              onChange={this.handleChange}
+            />
 
+            <p />
+            <label for="password"> Password:</label>
+            <input
+              type="password"
+              name="password"
+              value={this.state.password}
+              onChange={this.handleChange}
+            />
 
-         <p></p>
-        <label for="username">Username: </label>
-          <input
-            type="text"
-            name="username"
-            value={this.state.username}
-            onChange={this.handleChange}  />
-
-
-         <p></p>
-        <label for="email"> Email: </label>
-          <input
-            type="text"
-            name="email"
-            value={this.state.email}
-            onChange={this.handleChange}  />
-
-
-        <p></p>
-        <label for="age"> Age: </label>
-          <input
-            id="num"
-            type="number"
-            name="age"
-            value={this.state.age}
-            onChange={this.handleChange}  />
-
-
-
-          <p></p>
-        <label for="password"> Password:</label>
-          <input
-            type="password"
-            name="password"
-            value={this.state.password}
-            onChange={this.handleChange}  />
-
-
-          <p></p>
-        <label for="passwordConfirmation">Password Confirmation:</label>
-          <input
-            type="password"
-            name="passwordConfirmation"
-            value={null}
-            onChange={this.handleChange}  />
-
-            </section>
-      {/* **** End Section for Personal Info **** */}
-
-      {/* Starting Section on Bio and Social Media */}
-          <p></p>
+            <p />
+            <label for="passwordConfirmation">Password Confirmation:</label>
+            <input
+              type="password"
+              name="passwordConfirmation"
+              value={null}
+              onChange={this.handleChange}
+            />
+          </section>
+          <p />
+          {/* **** End Section for Personal Info **** */}
+          {/* Starting Section on Bio and Social Media */}
           <label for="xinfo">Social Media & Info</label>
           <section id="xinfo">
+            <p />
+            <label for="bio">Bio</label>
+            <p />
+            <textarea
+              type="text"
+              id="bio"
+              name="bio"
+              value={this.state.bio}
+              onChange={this.handleChange}
+            />
 
-          <p></p>
-          <label for="bio">Bio</label>
-          <p></p>
-          <textarea
-            type="text"
-            id="bio"
-            name="bio"
-            value={this.state.bio}
-            onChange={this.handleChange}  />
+            <p />
+            <label for="slackHandle">Slack Handle:</label>
+            <input
+              type="text"
+              name="slackHandle"
+              value={this.state.slackHandle}
+              onChange={this.handleChange}
+            />
 
+            <p />
+            <label for="linkedinURL">Linkedin URL:</label>
+            <input
+              type="text"
+              name="linkedinURL"
+              value={this.state.linkedinURL}
+              onChange={this.handleChange}
+            />
 
+            <p />
+            <label for="codeRepoURL">Code Repository URL:</label>
+            <input
+              type="text"
+              name="codeRepoURL"
+              value={this.state.codeRepoURL}
+              onChange={this.handleChange}
+            />
 
-          <p></p>
-        <label for="slackHandle">Slack Handle:</label>
-          <input
-            type="text"
-            name="slackHandle"
-            value={this.state.slackHandle}
-            onChange={this.handleChange}  />
+            <p />
+            <label for="menteeCapacity">Mentee Capacity:</label>
+            <input
+              id="num"
+              type="number"
+              name="menteeCapacity"
+              value={this.state.menteeCapacity}
+              onChange={this.handleChange}
+            />
 
-
-          <p></p>
-        <label for="linkedinURL">Linkedin URL:</label>
-          <input
-            type="text"
-            name="linkedinURL"
-            value={this.state.linkedinURL}
-            onChange={this.handleChange}  />
-
-
-          <p></p>
-        <label for="codeRepoURL">Code Repository URL:</label>
-          <input
-            type="text"
-            name="codeRepoURL"
-            value={this.state.codeRepoURL}
-            onChange={this.handleChange}  />
-
-
-          <p></p>
-        <label for="menteeCapacity">Mentee Capacity:</label>
-          <input
-            id="num"
-            type="number"
-            name="menteeCapacity"
-            value={this.state.menteeCapacity}
-            onChange={this.handleChange}  />
-
-
-          <p></p>
-
-       </section>
-       {/* Social Media Section End */}
-
-       {/* Beginning of Interests Section */}
-
-          <p></p>
-       <section id="interests">Areas of interest
-         <p></p>
-         <label for="portfolio">Portfolio/Code Review</label>
-         <input
-            name="portfolio"
-            type="checkbox"
-            checked={this.state.portfolio}
-            onChange={this.handleChange}  />
-
-          <p></p>
-          <label for="jobSearch">Job Search and Interviews</label>
-          <input
-               name="jobSearch"
-               type="checkbox"
-               checked={this.state.jobSearch}
-               onChange={this.handleChange} />
-
-          <p></p>
-          <label for="skills">Industry Trends, Skills, Technologies</label>
-          <input
-               name="skills"
-               type="checkbox"
-               checked={this.state.skills}
-               onChange={this.handleChange} />
-
-
-          <p></p>
-          <label for="leadership">Leadership, Management</label>
-          <input
-               name="leadership"
-               type="checkbox"
-               checked={this.state.leadership}
-               onChange={this.handleChange} />
-
-          <p></p>
-          <label for="business">Business, Entrepreneurship</label>
-          <input
-               name="business"
-               type="checkbox"
-               checked={this.state.business}
-               onChange={this.handleChange} />
-
-          <p></p>
-          <label for="careerGrowth">Career Growth</label>
-          <input
-               name="careerGrowth"
-               type="checkbox"
-               checked={this.state.careerGrowth}
-               onChange={this.handleChange} />
-
-        </section>
-
-
-          <p></p>
-        <input id="submitButton"
-          type="button"
-          value="Submit"
-          onClick={this.handleSubmit}/>
-
+            <p />
+          </section>
+          {/* Social Media Section End */}
+          {/* Beginning of Interests Section */}
+          <p />
+          <section id="interests">
+            Areas of interest
+            <p />
+            <label for="portfolio">Portfolio/Code Review</label>
+            <input
+              name="portfolio"
+              type="checkbox"
+              checked={this.state.portfolio}
+              onChange={this.handleChange}
+            />
+            <p />
+            <label for="jobSearch">Job Search and Interviews</label>
+            <input
+              name="jobSearch"
+              type="checkbox"
+              checked={this.state.jobSearch}
+              onChange={this.handleChange}
+            />
+            <p />
+            <label for="skills">Industry Trends, Skills, Technologies</label>
+            <input
+              name="skills"
+              type="checkbox"
+              checked={this.state.skills}
+              onChange={this.handleChange}
+            />
+            <p />
+            <label for="leadership">Leadership, Management</label>
+            <input
+              name="leadership"
+              type="checkbox"
+              checked={this.state.leadership}
+              onChange={this.handleChange}
+            />
+            <p />
+            <label for="business">Business, Entrepreneurship</label>
+            <input
+              name="business"
+              type="checkbox"
+              checked={this.state.business}
+              onChange={this.handleChange}
+            />
+            <p />
+            <label for="careerGrowth">Career Growth</label>
+            <input
+              name="careerGrowth"
+              type="checkbox"
+              checked={this.state.careerGrowth}
+              onChange={this.handleChange}
+            />
+          </section>
+          <p />
+          <input id="submitButton" type="button" value="Submit" onClick={this.handleSubmit} />
         </form>
-
-
-
       </div>
     );
   }
-
-
 }
+
 export default MentorRegister;

--- a/src/Main/Register/MentorRegister.js
+++ b/src/Main/Register/MentorRegister.js
@@ -1,241 +1,82 @@
 import React from 'react';
-import './MentorRegister.css';
-import TextField from '@material-ui/core/TextField';
+import { Field } from 'redux-form';
+import { withStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
 
-class MentorRegister extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      username: '',
-      firstname: '',
-      lastname: '',
-      password: '',
-      passwordConfirmation: '',
-      slackHandle: '',
-      linkedinURL: '',
-      codeRepoURL: '',
-      bio: '',
-      menteeCapacity: 0,
-      age: 0,
-      email: '',
-      portfolio: false,
-      jobSearch: false,
-      skills: false,
-      leadership: false,
-      business: false,
-      careerGrowth: false,
-    };
-    this.handleChange = this.handleChange.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-  }
+import TextField from '../forms/TextField';
+import SelectField from '../forms/SelectField';
 
-  handleChange(event) {
-    /* Handles Changes for all Values, checkbox, number, and text */
-    console.log(event.target);
-    const target = event.target;
-    const value = target.type === 'checkbox' ? target.checked : target.value;
-    const name = target.name;
-    console.log(value);
-    this.setState({
-      [name]: value,
-    });
-  }
+const styles = {
+  form: {
+    '@media (min-width: 1024px)': {
+      width: '675px',
+    },
+    margin: 'auto',
+    padding: '20px',
+  },
+};
 
-  handleSubmit(event) {
-    /* Handles Submit when submit button is pressed */
+const interests = [
+  { label: 'Portfolio/Code Review', value: 'portfolio' },
+  { label: 'Job Search and Interviews', value: 'jobSearch' },
+  { label: 'Industry Trends, Skills, Technologies', value: 'skills' },
+  { label: 'Leadership, Management', value: 'leadership' },
+  { label: 'Business, Entrepreneurship', value: 'business' },
+  { label: 'Career Growth', value: 'careerGrowth' },
+];
 
-    /* Super Agent should go here */
+const MentorRegister = ({ handleSubmit, classes }) => {
+  return (
+    <div className={classes.form}>
+      <h1>Mentor Registration</h1>
+      <form onSubmit={handleSubmit(() => {})} noValidate>
+        <label htmlFor="pinfo">Personal Information</label>
+        <section id="pinfo" name="personalinfo">
+          <Field name="firstname" label="First Name" component={TextField} />
+          <Field name="lastname" label="Last Name" component={TextField} />
+          <Field name="username" label="Username" component={TextField} required />
+          <Field name="email" label="Email" component={TextField} required />
+          <Field name="password" label="Password" type="password" component={TextField} required />
+          <Field
+            name="confirmPassword"
+            label="Confirm Password"
+            type="password"
+            component={TextField}
+            required
+          />
+        </section>
+        <br />
+        <label htmlFor="xinfo">Social Media & Info</label>
+        <section id="xinfo">
+          <Field name="bio" label="Bio" multiline rows="8" component={TextField} />
+          <Field name="slackHandle" label="Slack Handle" component={TextField} />
+          <Field name="linkedinURL" label="Linkedin URL" component={TextField} />
+          <Field name="codeRepoURL" label="Code Repository URL" component={TextField} />
+          <Field
+            name="menteeCapacity"
+            label="Mentee Capacity"
+            type="number"
+            component={TextField}
+          />
+        </section>
+        <br />
+        <label htmlFor="interests">Areas of interest</label>
+        <section id="interests">
+          <Field
+            name="interests"
+            label="Interests"
+            multiple
+            component={SelectField}
+            items={interests}
+          />
+        </section>
+        <br />
+        <Button variant="contained" type="submit" color="primary">
+          Submit
+        </Button>
+      </form>
+    </div>
+  );
+};
 
-    alert(
-      'A name and age were submitted. \nName:  ' + this.state.portfolio + ' Age: ' + this.state.age
-    );
-    console.log(this.state.age);
-    event.preventDefault();
-  }
-
-  checkPasswordMatch() {
-    /* Handles password matching confirmation */
-  }
-
-  render() {
-    return (
-      <div>
-        <h1>Registration Page for Mentor</h1>
-        <form onSubmit={this.handleSubmit}>
-          <label for="pinfo">Personal Information</label>
-          <section id="pinfo" name="personalinfo">
-            <TextField name="firstname" label="First Name" onChange={this.handleChange} />
-            <TextField
-              name="lastname"
-              label="Last Name"
-              value={this.state.lastname}
-              onChange={this.handleChange}
-            />
-            <p />
-            <label for="lastname">LastName:</label>
-            <input
-              type="text"
-              name="lastname"
-              value={this.state.lastname}
-              onChange={this.handleChange}
-            />
-
-            <p />
-            <label for="username">Username: </label>
-            <input
-              type="text"
-              name="username"
-              value={this.state.username}
-              onChange={this.handleChange}
-            />
-
-            <p />
-            <label for="email"> Email: </label>
-            <input type="text" name="email" value={this.state.email} onChange={this.handleChange} />
-
-            <p />
-            <label for="age"> Age: </label>
-            <input
-              id="num"
-              type="number"
-              name="age"
-              value={this.state.age}
-              onChange={this.handleChange}
-            />
-
-            <p />
-            <label for="password"> Password:</label>
-            <input
-              type="password"
-              name="password"
-              value={this.state.password}
-              onChange={this.handleChange}
-            />
-
-            <p />
-            <label for="passwordConfirmation">Password Confirmation:</label>
-            <input
-              type="password"
-              name="passwordConfirmation"
-              value={null}
-              onChange={this.handleChange}
-            />
-          </section>
-          <p />
-          {/* **** End Section for Personal Info **** */}
-          {/* Starting Section on Bio and Social Media */}
-          <label for="xinfo">Social Media & Info</label>
-          <section id="xinfo">
-            <p />
-            <label for="bio">Bio</label>
-            <p />
-            <textarea
-              type="text"
-              id="bio"
-              name="bio"
-              value={this.state.bio}
-              onChange={this.handleChange}
-            />
-
-            <p />
-            <label for="slackHandle">Slack Handle:</label>
-            <input
-              type="text"
-              name="slackHandle"
-              value={this.state.slackHandle}
-              onChange={this.handleChange}
-            />
-
-            <p />
-            <label for="linkedinURL">Linkedin URL:</label>
-            <input
-              type="text"
-              name="linkedinURL"
-              value={this.state.linkedinURL}
-              onChange={this.handleChange}
-            />
-
-            <p />
-            <label for="codeRepoURL">Code Repository URL:</label>
-            <input
-              type="text"
-              name="codeRepoURL"
-              value={this.state.codeRepoURL}
-              onChange={this.handleChange}
-            />
-
-            <p />
-            <label for="menteeCapacity">Mentee Capacity:</label>
-            <input
-              id="num"
-              type="number"
-              name="menteeCapacity"
-              value={this.state.menteeCapacity}
-              onChange={this.handleChange}
-            />
-
-            <p />
-          </section>
-          {/* Social Media Section End */}
-          {/* Beginning of Interests Section */}
-          <p />
-          <section id="interests">
-            Areas of interest
-            <p />
-            <label for="portfolio">Portfolio/Code Review</label>
-            <input
-              name="portfolio"
-              type="checkbox"
-              checked={this.state.portfolio}
-              onChange={this.handleChange}
-            />
-            <p />
-            <label for="jobSearch">Job Search and Interviews</label>
-            <input
-              name="jobSearch"
-              type="checkbox"
-              checked={this.state.jobSearch}
-              onChange={this.handleChange}
-            />
-            <p />
-            <label for="skills">Industry Trends, Skills, Technologies</label>
-            <input
-              name="skills"
-              type="checkbox"
-              checked={this.state.skills}
-              onChange={this.handleChange}
-            />
-            <p />
-            <label for="leadership">Leadership, Management</label>
-            <input
-              name="leadership"
-              type="checkbox"
-              checked={this.state.leadership}
-              onChange={this.handleChange}
-            />
-            <p />
-            <label for="business">Business, Entrepreneurship</label>
-            <input
-              name="business"
-              type="checkbox"
-              checked={this.state.business}
-              onChange={this.handleChange}
-            />
-            <p />
-            <label for="careerGrowth">Career Growth</label>
-            <input
-              name="careerGrowth"
-              type="checkbox"
-              checked={this.state.careerGrowth}
-              onChange={this.handleChange}
-            />
-          </section>
-          <p />
-          <input id="submitButton" type="button" value="Submit" onClick={this.handleSubmit} />
-        </form>
-      </div>
-    );
-  }
-}
-
-export default MentorRegister;
+export default withStyles(styles, { name: 'MentorRegister' })(MentorRegister);

--- a/src/Main/Register/MentorRegisterContainer.js
+++ b/src/Main/Register/MentorRegisterContainer.js
@@ -1,8 +1,0 @@
-import { reduxForm } from 'redux-form';
-
-import MentorRegister from './MentorRegister';
-import validate from './MentorRegisterValidation';
-
-export default reduxForm({ form: 'MentorRegister', initialValues: { interests: [] }, validate })(
-  MentorRegister
-);

--- a/src/Main/Register/MentorRegisterContainer.js
+++ b/src/Main/Register/MentorRegisterContainer.js
@@ -1,0 +1,8 @@
+import { reduxForm } from 'redux-form';
+
+import MentorRegister from './MentorRegister';
+import validate from './MentorRegisterValidation';
+
+export default reduxForm({ form: 'MentorRegister', initialValues: { interests: [] }, validate })(
+  MentorRegister
+);

--- a/src/Main/Register/MentorRegisterValidation.js
+++ b/src/Main/Register/MentorRegisterValidation.js
@@ -1,0 +1,45 @@
+import {
+  checkRequired,
+  checkTooLong,
+  checkTooShort,
+  checkUrl,
+  checkEmail,
+  checkPasswordsMatching,
+  checkNumberBetween,
+} from '../forms/validation';
+
+export const MAX_FIRST_NAME_LENGTH = 30;
+export const MAX_LAST_NAME_LENGTH = 30;
+export const MAX_USERNAME_LENGTH = 150;
+export const MAX_EMAIL_LENGTH = 75;
+export const MIN_PASSWORD_LENGTH = 8;
+export const MAX_BIO_LENGTH = 500;
+export const MAX_SLACK_HANDLE_LENGTH = 40;
+export const MAX_LINKEDIN_URL_LENGTH = 200;
+export const MAX_CODE_REPO_URL_LENGTH = 200;
+
+export default ({
+  firstname,
+  lastname,
+  username,
+  email,
+  password,
+  confirmPassword,
+  bio,
+  slackHandle,
+  linkedinURL,
+  codeRepoURL,
+  menteeCapacity,
+}) => ({
+  firstname: checkTooLong(firstname, MAX_FIRST_NAME_LENGTH),
+  lastname: checkTooLong(lastname, MAX_FIRST_NAME_LENGTH),
+  username: checkRequired(username) || checkTooLong(username, MAX_USERNAME_LENGTH),
+  email: checkRequired(email) || checkEmail(email) || checkTooLong(email, MAX_EMAIL_LENGTH),
+  password: checkRequired(password) || checkTooShort(password, MIN_PASSWORD_LENGTH),
+  confirmPassword: checkRequired(confirmPassword) || checkPasswordsMatching(confirmPassword, password),
+  bio: checkTooLong(bio, MAX_BIO_LENGTH),
+  slackHandle: checkTooLong(slackHandle, MAX_SLACK_HANDLE_LENGTH),
+  linkedinURL: checkTooLong(linkedinURL, MAX_LINKEDIN_URL_LENGTH) || checkUrl(linkedinURL),
+  codeRepoURL: checkTooLong(codeRepoURL, MAX_CODE_REPO_URL_LENGTH) || checkUrl(codeRepoURL),
+  menteeCapacity: checkNumberBetween(menteeCapacity, 0, 5),
+});

--- a/src/Main/Register/MentorRegistrationContainer.js
+++ b/src/Main/Register/MentorRegistrationContainer.js
@@ -1,0 +1,14 @@
+import { reduxForm } from 'redux-form';
+
+import Registration from './Registration';
+import validate from './RegistrationValidation';
+
+export default reduxForm({
+  form: 'MentorRegistration',
+  initialValues: { interests: [] },
+  validate,
+  onSubmit: () => {
+    console.log('here');
+  },
+  isMentor: true,
+})(Registration);

--- a/src/Main/Register/Registration.js
+++ b/src/Main/Register/Registration.js
@@ -25,7 +25,7 @@ const interests = [
   { label: 'Career Growth', value: 'careerGrowth' },
 ];
 
-const Registration = ({ handleSubmit, classes, isMentor }) => {
+export const Registration = ({ handleSubmit, classes, isMentor }) => {
   return (
     <div className={classes.form}>
       <h1>{(isMentor ? 'Mentor' : 'Mentee') + ' Registration'}</h1>

--- a/src/Main/Register/Registration.js
+++ b/src/Main/Register/Registration.js
@@ -25,11 +25,11 @@ const interests = [
   { label: 'Career Growth', value: 'careerGrowth' },
 ];
 
-const MentorRegister = ({ handleSubmit, classes }) => {
+const Registration = ({ handleSubmit, classes, isMentor }) => {
   return (
     <div className={classes.form}>
-      <h1>Mentor Registration</h1>
-      <form onSubmit={handleSubmit(() => {})} noValidate>
+      <h1>{(isMentor ? 'Mentor' : 'Mentee') + ' Registration'}</h1>
+      <form onSubmit={handleSubmit} noValidate>
         <label htmlFor="pinfo">Personal Information</label>
         <section id="pinfo" name="personalinfo">
           <Field name="firstname" label="First Name" component={TextField} />
@@ -52,12 +52,14 @@ const MentorRegister = ({ handleSubmit, classes }) => {
           <Field name="slackHandle" label="Slack Handle" component={TextField} />
           <Field name="linkedinURL" label="Linkedin URL" component={TextField} />
           <Field name="codeRepoURL" label="Code Repository URL" component={TextField} />
-          <Field
-            name="menteeCapacity"
-            label="Mentee Capacity"
-            type="number"
-            component={TextField}
-          />
+          {isMentor && (
+            <Field
+              name="menteeCapacity"
+              label="Mentee Capacity"
+              type="number"
+              component={TextField}
+            />
+          )}
         </section>
         <br />
         <label htmlFor="interests">Areas of interest</label>
@@ -79,4 +81,4 @@ const MentorRegister = ({ handleSubmit, classes }) => {
   );
 };
 
-export default withStyles(styles, { name: 'MentorRegister' })(MentorRegister);
+export default withStyles(styles, { name: 'Registration' })(Registration);

--- a/src/Main/Register/Registration.test.js
+++ b/src/Main/Register/Registration.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { Registration } from './Registration';
+
+const defaultProps = {
+  classes: {},
+};
+
+const setup = props => shallow(<Registration {...defaultProps} {...props} />);
+
+describe('<Registration />', () => {
+  it('renders snapshot correctly when "isMentor" is undefined', () => {
+    const wrapper = setup();
+
+    expect(wrapper.find('[name="menteeCapacity"]')).toHaveLength(0);
+  });
+
+  it('renders snapshot correctly when "isMentor" is true', () => {
+    const wrapper = setup({ isMentor: true });
+
+    expect(wrapper.find('[name="menteeCapacity"]')).toHaveLength(1);
+  });
+});

--- a/src/Main/Register/RegistrationValidation.js
+++ b/src/Main/Register/RegistrationValidation.js
@@ -36,7 +36,8 @@ export default ({
   username: checkRequired(username) || checkTooLong(username, MAX_USERNAME_LENGTH),
   email: checkRequired(email) || checkEmail(email) || checkTooLong(email, MAX_EMAIL_LENGTH),
   password: checkRequired(password) || checkTooShort(password, MIN_PASSWORD_LENGTH),
-  confirmPassword: checkRequired(confirmPassword) || checkPasswordsMatching(confirmPassword, password),
+  confirmPassword:
+    checkRequired(confirmPassword) || checkPasswordsMatching(confirmPassword, password),
   bio: checkTooLong(bio, MAX_BIO_LENGTH),
   slackHandle: checkTooLong(slackHandle, MAX_SLACK_HANDLE_LENGTH),
   linkedinURL: checkTooLong(linkedinURL, MAX_LINKEDIN_URL_LENGTH) || checkUrl(linkedinURL),

--- a/src/Main/Register/RegistrationValidation.test.js
+++ b/src/Main/Register/RegistrationValidation.test.js
@@ -1,0 +1,27 @@
+import validate from './RegistrationValidation';
+
+describe('Registration Validation', () => {
+  const optionalFields = [
+    'firstname',
+    'lastname',
+    'bio',
+    'slackHandle',
+    'linkedinURL',
+    'codeRepoURL',
+    'menteeCapacity',
+  ];
+
+  optionalFields.forEach(field => {
+    it(`${field} is optional`, () => {
+      expect(validate({})[field]).toBeUndefined();
+    });
+  });
+
+  const requiredFields = ['username', 'email', 'password', 'confirmPassword'];
+
+  requiredFields.forEach(field => {
+    it(`${field} is required`, () => {
+      expect(validate({})[field]).toEqual('Required');
+    });
+  });
+});

--- a/src/Main/actions/auth.js
+++ b/src/Main/actions/auth.js
@@ -9,28 +9,24 @@ export const TOKEN_RECEIVED = '@@jwt/TOKEN_RECEIVED';
 export const TOKEN_FAILURE = '@@jwt/TOKEN_FAILURE';
 
 export const login = (username, password) => ({
-    [RSAA]: {
-        endpoint: '/api/v1/token-auth/',
-        method: 'POST',
-        body: JSON.stringify({
-          'username': username,
-          'password': password
-        }),
-        headers: { 'Content-Type': 'application/json' },
-        types: [
-            LOGIN_REQUEST, LOGIN_SUCCESS, LOGIN_FAILURE
-        ]
-      }
-})
+  [RSAA]: {
+    endpoint: '/api/v1/token-auth/',
+    method: 'POST',
+    body: JSON.stringify({
+      username: username,
+      password: password,
+    }),
+    headers: { 'Content-Type': 'application/json' },
+    types: [LOGIN_REQUEST, LOGIN_SUCCESS, LOGIN_FAILURE],
+  },
+});
 
-export const refreshAccessToken = (token) => ({
-    [RSAA]: {
-        endpoint: '/api/v1/token-refresh/',
-        method: 'POST',
-        body: JSON.stringify({'token': token}),
-        headers: { 'Content-Type': 'application/json' },
-        types: [
-          TOKEN_REQUEST, TOKEN_RECEIVED, TOKEN_FAILURE
-        ]
-    }
-})
+export const refreshAccessToken = token => ({
+  [RSAA]: {
+    endpoint: '/api/v1/token-refresh/',
+    method: 'POST',
+    body: JSON.stringify({ token: token }),
+    headers: { 'Content-Type': 'application/json' },
+    types: [TOKEN_REQUEST, TOKEN_RECEIVED, TOKEN_FAILURE],
+  },
+});

--- a/src/Main/actions/echo.js
+++ b/src/Main/actions/echo.js
@@ -1,18 +1,16 @@
 import { RSAA } from 'redux-api-middleware';
-import { withAuth } from '../reducers'
+import { withAuth } from '../reducers';
 
 export const ECHO_REQUEST = '@@echo/ECHO_REQUEST';
 export const ECHO_SUCCESS = '@@echo/ECHO_SUCCESS';
 export const ECHO_FAILURE = '@@echo/ECHO_FAILURE';
 
-export const echo = (message) => ({
+export const echo = message => ({
   [RSAA]: {
-      endpoint: '/api/echo/',
-      method: 'POST',
-      body: JSON.stringify({message: message}),
-      headers: withAuth({ 'Content-Type': 'application/json' }),
-      types: [
-        ECHO_REQUEST, ECHO_SUCCESS, ECHO_FAILURE
-      ]
-  }
-})
+    endpoint: '/api/echo/',
+    method: 'POST',
+    body: JSON.stringify({ message: message }),
+    headers: withAuth({ 'Content-Type': 'application/json' }),
+    types: [ECHO_REQUEST, ECHO_SUCCESS, ECHO_FAILURE],
+  },
+});

--- a/src/Main/containers/Login.js
+++ b/src/Main/containers/Login.js
@@ -1,32 +1,35 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { Redirect } from 'react-router'
+import React from 'react';
+import { connect } from 'react-redux';
+import { Redirect } from 'react-router';
 
-import LoginForm from '../Login/LoginForm'
-import {login} from  '../actions/auth'
-import {authErrors, isAuthenticated} from '../reducers'
+import LoginForm from '../Login/LoginForm';
+import { login } from '../actions/auth';
+import { authErrors, isAuthenticated } from '../reducers';
 
-const Login = (props) => {
-  if(props.isAuthenticated) {
-     return  <Redirect to='/' />
+const Login = props => {
+  if (props.isAuthenticated) {
+    return <Redirect to="/" />;
   }
 
   return (
-     <div className="login-page">
-       <LoginForm {...props}/>
+    <div className="login-page">
+      <LoginForm {...props} />
     </div>
-  )
-}
+  );
+};
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
   errors: authErrors(state),
-  isAuthenticated: isAuthenticated(state)
-})
+  isAuthenticated: isAuthenticated(state),
+});
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   onSubmit: (username, password) => {
-    dispatch(login(username, password))
-  }
-})
+    dispatch(login(username, password));
+  },
+});
 
-export default connect(mapStateToProps, mapDispatchToProps)(Login);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Login);

--- a/src/Main/containers/PrivateRoute.js
+++ b/src/Main/containers/PrivateRoute.js
@@ -1,23 +1,31 @@
-import React from 'react'
-import { Route, Redirect } from 'react-router'
-import { connect } from 'react-redux'
-import * as reducers from '../reducers'
+import React from 'react';
+import { Route, Redirect } from 'react-router';
+import { connect } from 'react-redux';
+import * as reducers from '../reducers';
 
 const PrivateRoute = ({ component: Component, isAuthenticated, ...rest }) => (
-  <Route {...rest} render={props => (
-    isAuthenticated ? (
-      <Component {...props}/>
-    ) : (
-      <Redirect to={{
-        pathname: '/login',
-        state: { from: props.location }
-      }}/>
-    )
-  )}/>
-)
+  <Route
+    {...rest}
+    render={props =>
+      isAuthenticated ? (
+        <Component {...props} />
+      ) : (
+        <Redirect
+          to={{
+            pathname: '/login',
+            state: { from: props.location },
+          }}
+        />
+      )
+    }
+  />
+);
 
-const mapStateToProps = (state) => ({
-  isAuthenticated: reducers.isAuthenticated(state)
-})
+const mapStateToProps = state => ({
+  isAuthenticated: reducers.isAuthenticated(state),
+});
 
-export default connect(mapStateToProps, null)(PrivateRoute);
+export default connect(
+  mapStateToProps,
+  null
+)(PrivateRoute);

--- a/src/Main/forms/SelectField.js
+++ b/src/Main/forms/SelectField.js
@@ -1,0 +1,86 @@
+import MenuItem from '@material-ui/core/MenuItem';
+import MuiTextField from '@material-ui/core/TextField';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+// SelectField will show 5.5 menu items by default. Scrollbar will auto-show
+// if there are more items.
+const VISIBLE_MENU_ITEM_COUNT = 5.5;
+
+// Hardcoded values from material-ui source
+const MUI_MENU_ITEM_HEIGHT = 32;
+const MUI_MENU_PADDING_TOP = 8;
+
+const maxHeight = MUI_MENU_ITEM_HEIGHT * VISIBLE_MENU_ITEM_COUNT + MUI_MENU_PADDING_TOP;
+const MenuProps = { PaperProps: { style: { maxHeight } } };
+
+const SelectField = ({
+  className,
+  disabled,
+  helperText,
+  items,
+  label,
+  multiple,
+  required,
+  displayEmpty,
+  input: { name, value, onBlur, onChange },
+  meta: { touched, error } = {},
+}) => {
+  const hasError = touched && !!error;
+  const hasHelperText = !!helperText;
+  const separator = (hasError && hasHelperText && ' | ') || '';
+  const combinedHelperText = (
+    <span>
+      {hasError && error}
+      {separator}
+      {hasHelperText && helperText}
+    </span>
+  );
+
+  return (
+    <MuiTextField
+      select
+      id={name}
+      value={value}
+      label={label}
+      className={className}
+      disabled={disabled}
+      error={hasError}
+      fullWidth
+      margin="normal"
+      required={required}
+      helperText={combinedHelperText}
+      SelectProps={{ MenuProps, multiple, displayEmpty }}
+      onBlur={event => onBlur && onBlur(event.target.value)}
+      onChange={event => onChange(event.target.value)}
+    >
+      {items &&
+        items.map(item => (
+          <MenuItem key={item.value} value={item.value}>
+            {item.label}
+          </MenuItem>
+        ))}
+    </MuiTextField>
+  );
+};
+
+SelectField.propTypes = {
+  input: PropTypes.shape({
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+    ]),
+    onChange: PropTypes.func.isRequired,
+  }).isRequired,
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      label: PropTypes.string,
+    })
+  ).isRequired,
+};
+
+SelectField.displayName = 'SelectField';
+
+export default SelectField;

--- a/src/Main/forms/TextField.js
+++ b/src/Main/forms/TextField.js
@@ -1,0 +1,23 @@
+import { TextField as MuiTextField } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
+import React from 'react';
+
+const styles = {
+  width: {},
+};
+
+export const TextField = ({ input, classes, meta: { touched, error }, ...rest }) => (
+  <MuiTextField
+    {...input}
+    error={touched && !!error}
+    helperText={touched && error}
+    margin="normal"
+    {...rest}
+    fullWidth
+    className={classes.width}
+  />
+);
+
+TextField.displayName = 'TextField';
+
+export default withStyles(styles, { name: 'TextField' })(TextField);

--- a/src/Main/forms/validation.js
+++ b/src/Main/forms/validation.js
@@ -11,32 +11,30 @@ export const checkNormalSymbolsOnly = value => {
 };
 
 export const checkTooLong = (value, length) => {
-  if (value) {
-    if (value.length > length) {
-      return `Must be ${length} characters or less`;
-    }
+  if (value && value.length > length) {
+    return `Must be ${length} characters or less`;
   }
 };
 
 export const checkTooShort = (value, length) => {
-  if (value) {
-    if (value.length < length) {
-      return `Must be ${length} characters or more`;
-    }
+  if (value && value.length < length) {
+    return `Must be ${length} characters or more`;
   }
 };
 
 export const checkUrl = value => {
-  const test = /^(http:\/\/|https:\/\/)[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?([^\s]+)?$/.test(
-    value
-  );
-  if (!test) {
+  if (
+    value &&
+    !/^(http:\/\/|https:\/\/)[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?([^\s]+)?$/.test(
+      value
+    )
+  ) {
     return 'Must be a valid URL';
   }
 };
 
 export const checkEmail = value => {
-  if (!/^[a-zA-Z0-9.!#$%&’*+/=?^_{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+$/.test(value)) {
+  if (value && !/^[a-zA-Z0-9.!#$%&’*+/=?^_{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+$/.test(value)) {
     return 'Must be a valid email';
   }
 };

--- a/src/Main/forms/validation.js
+++ b/src/Main/forms/validation.js
@@ -1,0 +1,58 @@
+export const checkRequired = value => {
+  if (!value || (typeof value === 'string' && !value.trim())) {
+    return 'Required';
+  }
+};
+
+export const checkNormalSymbolsOnly = value => {
+  if (!/^[\w\s]+$/i.test(value)) {
+    return 'Must contain only valid characters';
+  }
+};
+
+export const checkTooLong = (value, length) => {
+  if (value) {
+    if (value.length > length) {
+      return `Must be ${length} characters or less`;
+    }
+  }
+};
+
+export const checkTooShort = (value, length) => {
+  if (value) {
+    if (value.length < length) {
+      return `Must be ${length} characters or more`;
+    }
+  }
+};
+
+export const checkUrl = value => {
+  const test = /^(http:\/\/|https:\/\/)[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?([^\s]+)?$/.test(
+    value
+  );
+  if (!test) {
+    return 'Must be a valid URL';
+  }
+};
+
+export const checkEmail = value => {
+  if (!/^[a-zA-Z0-9.!#$%&’*+/=?^_{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+$/.test(value)) {
+    return 'Must be a valid email';
+  }
+};
+
+export const checkPasswordsMatching = (value1, value2) => {
+  if (value1 !== value2) {
+    return 'Passwords must match';
+  }
+};
+
+export const checkNumberBetween = (value, min, max) => {
+  if (
+    (value && !/^[0-9]+$/i.test(value)) ||
+    parseInt(value, 10) < min ||
+    parseInt(value, 10) > max
+  ) {
+    return `Must be between ${min} and ${max}`;
+  }
+};

--- a/src/Main/forms/validation.js
+++ b/src/Main/forms/validation.js
@@ -17,7 +17,7 @@ export const checkTooLong = (value, length) => {
 };
 
 export const checkTooShort = (value, length) => {
-  if (value && value.length < length) {
+  if (!value || value.length < length) {
     return `Must be ${length} characters or more`;
   }
 };

--- a/src/Main/forms/validation.test.js
+++ b/src/Main/forms/validation.test.js
@@ -1,0 +1,215 @@
+import {
+  checkRequired,
+  checkTooLong,
+  checkTooShort,
+  checkUrl,
+  checkEmail,
+  checkPasswordsMatching,
+  checkNumberBetween,
+} from './validation';
+
+describe('checkRequired', () => {
+  const validInputCases = ['some text', '  trim me   ', { fooObject: 'bar' }, 20];
+
+  const invalidInputCases = ['', ' ', ' \n ', '   \t  ', null, undefined];
+
+  validInputCases.forEach(validInput => {
+    it(`returns undefined for valid input: "${validInput}"`, () => {
+      const result = checkRequired(validInput);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  invalidInputCases.forEach(invalidInput => {
+    it(`renders message for invalid input: "${invalidInput}"`, () => {
+      const result = checkRequired(invalidInput);
+
+      expect(result).toEqual('Required');
+    });
+  });
+});
+
+describe('checkTooLong', () => {
+  const testcases = [
+    { value: '7 chars', maxLength: 6, expectError: true },
+    { value: '7 chars', maxLength: 7, expectError: false },
+    { value: '7 chars', maxLength: 8, expectError: false },
+    { value: 'Test Text', maxLength: 5, expectError: true },
+    { value: '', maxLength: 0, expectError: false },
+    { value: '', maxLength: 5, expectError: false },
+    { value: [], maxLength: 5, expectError: false },
+    { value: [1, 2, 3], maxLength: 2, expectError: true },
+  ];
+  testcases.forEach(({ value, maxLength, expectError }) => {
+    it(`handles validation for input: ${value}, maxLength: ${maxLength}`, () => {
+      const result = checkTooLong(value, maxLength);
+
+      if (expectError) {
+        expect(result).toEqual(`Must be ${maxLength} characters or less`);
+      } else {
+        expect(result).toBeUndefined();
+      }
+    });
+  });
+});
+
+describe('checkTooShort', () => {
+  const testcases = [
+    { value: '7 chars', minLength: 6, expectError: false },
+    { value: '7 chars', minLength: 7, expectError: false },
+    { value: '7 chars', minLength: 8, expectError: true },
+    { value: 'Test Text', minLength: 5, expectError: false },
+    { value: '', minLength: 1, expectError: true },
+    { value: '', minLength: 5, expectError: true },
+    { value: [], minLength: 5, expectError: true },
+    { value: [1, 2, 3], minLength: 2, expectError: false },
+  ];
+  testcases.forEach(({ value, minLength, expectError }) => {
+    it(`handles validation for input: ${value}, minLength: ${minLength}`, () => {
+      const result = checkTooShort(value, minLength);
+
+      if (expectError) {
+        expect(result).toEqual(`Must be ${minLength} characters or more`);
+      } else {
+        expect(result).toBeUndefined();
+      }
+    });
+  });
+});
+
+describe('checkUrl', () => {
+  const validUrlCases = [
+    'http://www.example.com',
+    'http://www.example.com/this/is!/A/Test22(?-*)/',
+    'https://www.example.com/123123/?hello',
+    'https://example.com/hello-world!',
+    'https://yes.example.com/',
+    'https://yes.foo.bar.fizz.buzz.dinosaur.derp.doo.dee.bee.ooo.example.com/',
+    '',
+    null,
+    undefined,
+  ];
+
+  const invalidUrlCases = [
+    '   \t  ',
+    'http://www. example.com',
+    'h ttp://www.example.com',
+    'http://ww w.example.com',
+    'http://www.example.com /hello',
+    'www.example.com',
+    'http://w ww.!a;sdasdksd.com /09h09h2',
+    'https://example.com/hello-     world!',
+  ];
+
+  validUrlCases.forEach(validUrl => {
+    it(`returns undefined for valid input: "${validUrl}"`, () => {
+      const result = checkUrl(validUrl);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  invalidUrlCases.forEach(invalidUrl => {
+    it(`renders message for invalid input: "${invalidUrl}"`, () => {
+      const result = checkUrl(invalidUrl);
+
+      expect(result).toEqual('Must be a valid URL');
+    });
+  });
+});
+
+describe('checkEmail', () => {
+  const validEmailCases = [
+    'foo@example.com',
+    'FOO@example.com',
+    'foo.bar@example.co.jp',
+    'foo+bar@baz.org',
+    undefined,
+    null,
+  ];
+
+  const invalidEmailCases = ['foo', 'foo@com', 'foo@.com', '@example.com', ' '];
+
+  validEmailCases.forEach(validEmail => {
+    it(`returns undefined for valid input: "${validEmail}"`, () => {
+      const result = checkEmail(validEmail);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  invalidEmailCases.forEach(invalidEmail => {
+    it(`renders message for invalid input: "${invalidEmail}"`, () => {
+      const result = checkEmail(invalidEmail);
+
+      expect(result).toEqual('Must be a valid email');
+    });
+  });
+});
+
+describe('checkPasswordsMatching', () => {
+  const validCases = [
+    { value1: 'a', value2: 'a' },
+    { value1: 'abcd', value2: 'abcd' },
+    { value1: '!@#$%^&*()1234567890', value2: '!@#$%^&*()1234567890' },
+    { value1: 'hunter2', value2: 'hunter2' },
+  ];
+
+  const invalidCases = [
+    { value1: 'a', value2: 'b' },
+    { value1: 'a', value2: 'b ' },
+    { value1: 'abcd', value2: 'abcde' },
+    { value1: '!@#$%^&*()1234567890', value2: '1234567890!@#$%^&*()' },
+    { value1: 'hunter2', value2: 'hunter3' },
+  ];
+
+  validCases.forEach(({ value1, value2 }) => {
+    it(`returns undefined for valid input: "${value1}" and "${value2}"`, () => {
+      const result = checkPasswordsMatching(value1, value2);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  invalidCases.forEach(({ value1, value2 }) => {
+    it(`renders message for invalid input: "${value1}" and "${value2}"`, () => {
+      const result = checkPasswordsMatching(value1, value2);
+
+      expect(result).toEqual('Passwords must match');
+    });
+  });
+});
+
+describe('checkNumberBetween', () => {
+  const validCases = [
+    { value: 1, min: 1, max: 1 },
+    { value: 0, min: 0, max: 10 },
+    { value: 10, min: 0, max: 10 },
+    { value: 5, min: 0, max: 10 },
+  ];
+
+  const invalidCases = [
+    { value: 0, min: 1, max: 1 },
+    { value: -1, min: 1, max: 1 },
+    { value: 2, min: 1, max: 1 },
+    { value: 0, min: 1, max: 10 },
+    { value: 10, min: 1, max: 9 },
+  ];
+
+  validCases.forEach(({ value, min, max }) => {
+    it(`returns undefined for valid input: value="${value}", min="${min}" and max="${max}"`, () => {
+      const result = checkNumberBetween(value, min, max);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  invalidCases.forEach(({ value, min, max }) => {
+    it(`renders message for invalid input: value="${value}", min="${min}" and max="${max}"`, () => {
+      const result = checkNumberBetween(value, min, max);
+
+      expect(result).toEqual(`Must be between ${min} and ${max}`);
+    });
+  });
+});

--- a/src/Main/reducers/auth.js
+++ b/src/Main/reducers/auth.js
@@ -1,77 +1,76 @@
-import jwtDecode from 'jwt-decode'
-import * as auth from '../actions/auth'
-
+import jwtDecode from 'jwt-decode';
+import * as auth from '../actions/auth';
 
 const initialState = {
   access: undefined,
   refresh: undefined,
   errors: {},
-}
+};
 
-export default (state=initialState, action) => {
-  switch(action.type) {
+export default (state = initialState, action) => {
+  switch (action.type) {
     case auth.LOGIN_SUCCESS:
       return {
         access: {
           token: action.payload.token,
-          ...jwtDecode(action.payload.token)
+          ...jwtDecode(action.payload.token),
         },
         refresh: {
           token: action.payload.token,
-          ...jwtDecode(action.payload.token)
+          ...jwtDecode(action.payload.token),
         },
-        errors: {}
-    }
+        errors: {},
+      };
     case auth.TOKEN_RECEIVED:
       return {
         ...state,
         access: {
           token: action.payload.token,
-          ...jwtDecode(action.payload.token)
-        }
-      }
+          ...jwtDecode(action.payload.token),
+        },
+      };
     case auth.LOGIN_FAILURE:
     case auth.TOKEN_FAILURE:
       return {
-         access: undefined,
-         refresh: undefined,
-         errors: action.payload.response || {'non_field_errors': action.payload.statusText},
-      }
+        access: undefined,
+        refresh: undefined,
+        errors: action.payload.response || { non_field_errors: action.payload.statusText },
+      };
     default:
-      return state
-    }
-}
+      return state;
+  }
+};
 
 export function accessToken(state) {
   if (state.access) {
-    return  state.access.token
+    return state.access.token;
   }
 }
 
 export function isAccessTokenExpired(state) {
   if (state.access && state.access.exp) {
-    return 1000 * state.access.exp - (new Date()).getTime() < 5000
+    return 1000 * state.access.exp - new Date().getTime() < 5000;
   }
-  return true
+  return true;
 }
 
 export function refreshToken(state) {
   if (state.refresh) {
-    return  state.refresh.token
+    return state.refresh.token;
   }
 }
 
 export function isRefreshTokenExpired(state) {
   if (state.refresh && state.refresh.exp) {
-    return 1000 * state.refresh.exp - (new Date()).getTime() < 5000
+    return 1000 * state.refresh.exp - new Date().getTime() < 5000;
   }
-  return true
+  return true;
 }
 
 export function isAuthenticated(state) {
-  return !isRefreshTokenExpired(state)
+  return !isRefreshTokenExpired(state);
 }
 
 export function errors(state) {
-  return  state.errors
+  return state.errors;
 }

--- a/src/Main/reducers/echo.js
+++ b/src/Main/reducers/echo.js
@@ -1,18 +1,18 @@
-import * as echo from '../actions/echo'
+import * as echo from '../actions/echo';
 
 const initialState = {
-  message: ""
-}
+  message: '',
+};
 
-export default (state=initialState, action) => {
-  switch(action.type) {
+export default (state = initialState, action) => {
+  switch (action.type) {
     case echo.ECHO_SUCCESS:
       return {
-        message: action.payload.message
-      }
+        message: action.payload.message,
+      };
     default:
-      return state
+      return state;
   }
-}
+};
 
-export const serverMessage = (state) => state.message
+export const serverMessage = state => state.message;

--- a/src/Main/reducers/index.js
+++ b/src/Main/reducers/index.js
@@ -1,5 +1,7 @@
 import { combineReducers } from 'redux';
 import { routerReducer } from 'react-router-redux';
+import { reducer as formReducer } from 'redux-form';
+
 import auth, * as fromAuth from './auth.js';
 import echo, * as fromEcho from './echo.js';
 
@@ -7,6 +9,7 @@ export default combineReducers({
   auth: auth,
   echo: echo,
   router: routerReducer,
+  form: formReducer,
 });
 
 export const isAuthenticated = state => fromAuth.isAuthenticated(state.auth);

--- a/src/Main/reducers/index.js
+++ b/src/Main/reducers/index.js
@@ -1,26 +1,25 @@
-import { combineReducers } from 'redux'
-import { routerReducer } from 'react-router-redux'
-import auth, * as fromAuth from './auth.js'
-import echo, * as fromEcho from './echo.js'
+import { combineReducers } from 'redux';
+import { routerReducer } from 'react-router-redux';
+import auth, * as fromAuth from './auth.js';
+import echo, * as fromEcho from './echo.js';
 
 export default combineReducers({
   auth: auth,
   echo: echo,
-  router: routerReducer
-})
+  router: routerReducer,
+});
 
+export const isAuthenticated = state => fromAuth.isAuthenticated(state.auth);
+export const accessToken = state => fromAuth.accessToken(state.auth);
+export const isAccessTokenExpired = state => fromAuth.isAccessTokenExpired(state.auth);
+export const refreshToken = state => fromAuth.refreshToken(state.auth);
+export const isRefreshTokenExpired = state => fromAuth.isRefreshTokenExpired(state.auth);
+export const authErrors = state => fromAuth.errors(state.auth);
+export const serverMessage = state => fromEcho.serverMessage(state.echo);
 
-export const isAuthenticated = state => fromAuth.isAuthenticated(state.auth)
-export const accessToken = state => fromAuth.accessToken(state.auth)
-export const isAccessTokenExpired = state => fromAuth.isAccessTokenExpired(state.auth)
-export const refreshToken = state => fromAuth.refreshToken(state.auth)
-export const isRefreshTokenExpired = state => fromAuth.isRefreshTokenExpired(state.auth)
-export const authErrors = state => fromAuth.errors(state.auth)
-export const serverMessage = state => fromEcho.serverMessage(state.echo)
-
-export function withAuth(headers={}) {
-  return (state) => ({
+export function withAuth(headers = {}) {
+  return state => ({
     ...headers,
-    'Authorization': `Bearer ${accessToken(state)}`
-  })
+    Authorization: `Bearer ${accessToken(state)}`,
+  });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ import { Provider } from 'react-redux';
 
 import './index.css';
 import App from './App';
-import PrivateRoute from './Main/containers/PrivateRoute';
 import Login from './Main/containers/Login';
 import configureStore from './store';
 import registerServiceWorker from './registerServiceWorker';
@@ -20,7 +19,7 @@ ReactDOM.render(
     <Router history={history}>
       <Switch>
         <Route exact path="/login/" component={Login} />
-        <PrivateRoute path="/" component={App} />
+        <Route path="/" component={App} />
       </Switch>
     </Router>
   </Provider>,

--- a/src/index.js
+++ b/src/index.js
@@ -11,21 +11,20 @@ import Login from './Main/containers/Login';
 import configureStore from './store';
 import registerServiceWorker from './registerServiceWorker';
 
+const history = createHistory();
 
-const history = createHistory()
+const store = configureStore(history);
 
-const store = configureStore(history)
-
-ReactDOM.render((
-    <Provider store={store}>
+ReactDOM.render(
+  <Provider store={store}>
     <Router history={history}>
-    <Switch>
+      <Switch>
         <Route exact path="/login/" component={Login} />
-        <PrivateRoute path="/" component={App}/>
-    </Switch>
+        <PrivateRoute path="/" component={App} />
+      </Switch>
     </Router>
-    </Provider>
-  ), document.getElementById('root'));
- 
- 
-  registerServiceWorker();
+  </Provider>,
+  document.getElementById('root')
+);
+
+registerServiceWorker();

--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -13,9 +13,7 @@ const isLocalhost = Boolean(
     // [::1] is the IPv6 localhost address.
     window.location.hostname === '[::1]' ||
     // 127.0.0.1/8 is considered localhost for IPv4.
-    window.location.hostname.match(
-      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
-    )
+    window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
 );
 
 export default function register() {
@@ -102,9 +100,7 @@ function checkValidServiceWorker(swUrl) {
       }
     })
     .catch(() => {
-      console.log(
-        'No internet connection found. App is running in offline mode.'
-      );
+      console.log('No internet connection found. App is running in offline mode.');
     });
 }
 

--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,5 @@
 import storage from 'redux-persist/es/storage';
-import { applyMiddleware, createStore } from 'redux';
+import { applyMiddleware, createStore, compose } from 'redux';
 import { createFilter } from 'redux-persist-transform-filter';
 import { persistReducer, persistStore } from 'redux-persist';
 import { routerMiddleware } from 'react-router-redux';
@@ -20,7 +20,13 @@ export default history => {
     rootReducer
   );
 
-  const store = createStore(reducer, {}, applyMiddleware(apiMiddleware, routerMiddleware(history)));
+  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+
+  const store = createStore(
+    reducer,
+    {},
+    composeEnhancers(applyMiddleware(apiMiddleware, routerMiddleware(history)))
+  );
 
   persistStore(store);
 

--- a/src/store.js
+++ b/src/store.js
@@ -1,33 +1,28 @@
-import storage from 'redux-persist/es/storage'
-import { applyMiddleware, createStore } from 'redux'
-import { createFilter   } from 'redux-persist-transform-filter';
-import { persistReducer, persistStore } from 'redux-persist'
-import { routerMiddleware } from 'react-router-redux'
+import storage from 'redux-persist/es/storage';
+import { applyMiddleware, createStore } from 'redux';
+import { createFilter } from 'redux-persist-transform-filter';
+import { persistReducer, persistStore } from 'redux-persist';
+import { routerMiddleware } from 'react-router-redux';
 
 import apiMiddleware from './middleware';
-import rootReducer from './Main/reducers'
+import rootReducer from './Main/reducers';
 
-export default (history) => {
-  const persistedFilter = createFilter(
-    'auth', ['access', 'refresh']
-  );
+export default history => {
+  const persistedFilter = createFilter('auth', ['access', 'refresh']);
 
   const reducer = persistReducer(
     {
       key: 'polls',
       storage: storage,
       whitelist: ['auth'],
-      transforms: [ persistedFilter]
+      transforms: [persistedFilter],
     },
     rootReducer
-  )
+  );
 
-  const store = createStore(
-    reducer, {},
-    applyMiddleware(apiMiddleware, routerMiddleware(history))
-  )
+  const store = createStore(reducer, {}, applyMiddleware(apiMiddleware, routerMiddleware(history)));
 
-  persistStore(store)
+  persistStore(store);
 
-  return store
-}
+  return store;
+};

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,0 +1,5 @@
+import 'raf/polyfill';
+import Adapter from 'enzyme-adapter-react-16';
+import Enzyme from 'enzyme';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,10 @@
     csstype "^2.0.0"
     indefinite-observable "^1.0.1"
 
+"@types/node@*":
+  version "10.9.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
+
 "@types/prop-types@*":
   version "15.5.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.5.tgz#17038dd322c2325f5da650a94d5f9974943625e3"
@@ -314,6 +318,14 @@ array-unique@^0.2.1:
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+
+array.prototype.flat@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz#812db8f02cad24d3fab65dd67eabe3b8903494a4"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.10.0"
+    function-bind "^1.1.1"
 
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
@@ -1438,6 +1450,17 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
+cheerio@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
+
 chokidar@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -1606,6 +1629,10 @@ colormin@^1.0.5:
     color "^0.11.0"
     css-color-names "0.0.4"
     has "^1.0.1"
+
+colors@0.5.x:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
 
 colors@~1.1.2:
   version "1.1.2"
@@ -1838,7 +1865,7 @@ css-loader@0.28.7:
     postcss-value-parser "^3.3.0"
     source-list-map "^2.0.0"
 
-css-select@^1.1.0:
+css-select@^1.1.0, css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
   dependencies:
@@ -2112,6 +2139,10 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
@@ -2152,7 +2183,7 @@ dom-helpers@^3.2.1, dom-helpers@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
-dom-serializer@0:
+dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   dependencies:
@@ -2169,7 +2200,7 @@ domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
 
-domelementtype@1:
+domelementtype@1, domelementtype@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
 
@@ -2183,6 +2214,12 @@ domhandler@2.1:
   dependencies:
     domelementtype "1"
 
+domhandler@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
+  dependencies:
+    domelementtype "1"
+
 domutils@1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485"
@@ -2192,6 +2229,13 @@ domutils@1.1:
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -2272,9 +2316,52 @@ enhanced-resolve@^3.4.0:
     object-assign "^4.0.1"
     tapable "^0.2.7"
 
-entities@~1.1.1:
+entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+enzyme-adapter-react-16@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.3.1.tgz#a0f04273aee62c47521da7a2f6c7134182bd7f73"
+  dependencies:
+    enzyme-adapter-utils "^1.6.0"
+    function.prototype.name "^1.1.0"
+    object.assign "^4.1.0"
+    object.values "^1.0.4"
+    prop-types "^15.6.2"
+    react-is "^16.4.2"
+    react-test-renderer "^16.0.0-0"
+
+enzyme-adapter-utils@^1.6.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.6.1.tgz#f19acb8b23ddd21b2de99506b181e46138368f2a"
+  dependencies:
+    function.prototype.name "^1.1.0"
+    object.assign "^4.1.0"
+    prop-types "^15.6.2"
+
+enzyme@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.5.0.tgz#fd452a698fd1352c737b641dd3a64e079f42d9d5"
+  dependencies:
+    array.prototype.flat "^1.2.1"
+    cheerio "^1.0.0-rc.2"
+    function.prototype.name "^1.1.0"
+    has "^1.0.3"
+    is-boolean-object "^1.0.0"
+    is-callable "^1.1.4"
+    is-number-object "^1.0.3"
+    is-string "^1.0.4"
+    is-subset "^0.1.1"
+    lodash.escape "^4.0.1"
+    lodash.isequal "^4.5.0"
+    object-inspect "^1.6.0"
+    object-is "^1.0.1"
+    object.assign "^4.1.0"
+    object.entries "^1.0.4"
+    object.values "^1.0.4"
+    raf "^3.4.0"
+    rst-selector-parser "^2.2.3"
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
@@ -2288,7 +2375,7 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.7.0:
+es-abstract@^1.10.0, es-abstract@^1.6.1, es-abstract@^1.7.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
   dependencies:
@@ -3072,9 +3159,17 @@ fsevents@^1.0.0, fsevents@^1.1.3, fsevents@^1.2.2:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
-function-bind@^1.1.1:
+function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+
+function.prototype.name@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.0.tgz#8bd763cc0af860a859cc5d49384d74b932cd2327"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    is-callable "^1.1.3"
 
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
@@ -3276,6 +3371,10 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -3415,6 +3514,17 @@ html-webpack-plugin@2.29.0:
     lodash "^4.17.3"
     pretty-error "^2.0.2"
     toposort "^1.0.0"
+
+htmlparser2@^3.9.1:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
 
 htmlparser2@~3.3.0:
   version "3.3.0"
@@ -3645,6 +3755,10 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
+is-boolean-object@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -3655,7 +3769,7 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-callable@^1.1.1, is-callable@^1.1.3:
+is-callable@^1.1.1, is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
 
@@ -3782,6 +3896,10 @@ is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
 
+is-number-object@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -3865,6 +3983,14 @@ is-root@1.0.0:
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-string@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
+
+is-subset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
 
 is-svg@^2.0.0:
   version "2.1.0"
@@ -4571,6 +4697,14 @@ lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
+lodash.escape@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
+
+lodash.flattendeep@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+
 lodash.forin@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.forin/-/lodash.forin-4.4.0.tgz#5d3f20ae564011fbe88381f7d98949c9c9519731"
@@ -4582,6 +4716,10 @@ lodash.get@^4.4.2:
 lodash.isempty@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.isfunction@^3.0.9:
   version "3.0.9"
@@ -4880,6 +5018,10 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
   dependencies:
     minimist "0.0.8"
 
+moo@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -4922,6 +5064,16 @@ nanomatch@^1.2.9:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+nearley@^2.7.10:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.15.1.tgz#965e4e6ec9ed6b80fc81453e161efbcebb36d247"
+  dependencies:
+    moo "^0.4.3"
+    nomnom "~1.6.2"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
+    semver "^5.4.1"
 
 needle@^2.2.1:
   version "2.2.1"
@@ -5015,6 +5167,13 @@ node-pre-gyp@^0.10.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+nomnom@~1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
+  dependencies:
+    colors "0.5.x"
+    underscore "~1.4.4"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -5119,7 +5278,15 @@ object-hash@^1.1.4:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.0.tgz#76d9ba6ff113cf8efc0d996102851fe6723963e2"
 
-object-keys@^1.0.8:
+object-inspect@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
+
+object-is@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
+
+object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
 
@@ -5128,6 +5295,24 @@ object-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   dependencies:
     isobject "^3.0.0"
+
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
+
+object.entries@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -5141,6 +5326,15 @@ object.pick@^1.3.0:
   resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
   dependencies:
     isobject "^3.0.1"
+
+object.values@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 obuf@^1.0.0, obuf@^1.1.1:
   version "1.1.2"
@@ -5312,6 +5506,12 @@ parse-passwd@^1.0.0:
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  dependencies:
+    "@types/node" "*"
 
 parseurl@~1.3.2:
   version "1.3.2"
@@ -5867,11 +6067,22 @@ querystringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
 
-raf@3.4.0:
+raf@3.4.0, raf@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
   dependencies:
     performance-now "^2.1.0"
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 randomatic@^3.0.0:
   version "3.0.0"
@@ -5959,6 +6170,10 @@ react-event-listener@^0.6.2:
     "@babel/runtime" "7.0.0-beta.42"
     prop-types "^15.6.0"
     warning "^4.0.1"
+
+react-is@^16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
 
 react-jss@^8.1.0:
   version "8.6.1"
@@ -6063,6 +6278,15 @@ react-scripts@1.1.4:
     whatwg-fetch "2.0.3"
   optionalDependencies:
     fsevents "^1.1.3"
+
+react-test-renderer@^16.0.0-0:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.4.2.tgz#4e03eca9359bb3210d4373f7547d1364218ef74e"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.4.2"
 
 react-transition-group@^2.2.1, react-transition-group@^2.3.1:
   version "2.4.0"
@@ -6471,6 +6695,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rst-selector-parser@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
+  dependencies:
+    lodash.flattendeep "^4.4.0"
+    nearley "^2.7.10"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -7257,6 +7488,10 @@ uglifyjs-webpack-plugin@^0.4.6:
     source-map "^0.5.6"
     uglify-js "^2.8.29"
     webpack-sources "^1.0.1"
+
+underscore@~1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
 
 union-value@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2314,6 +2314,10 @@ es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
     es6-symbol "~3.1.1"
     next-tick "1"
 
+es6-error@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
+
 es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
@@ -3345,7 +3349,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0, hoist-non-react-statics@^2.5.4:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
@@ -4539,7 +4543,7 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.5:
+lodash-es@^4.17.10, lodash-es@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
 
@@ -6196,6 +6200,19 @@ redux-api-middleware@^2.3.0:
     babel-plugin-transform-runtime "^6.23.0"
     babel-runtime "^6.25.0"
     lodash.isplainobject "^4.0.6"
+
+redux-form@7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-7.4.2.tgz#d6061088fb682eb9fc5fb9749bd8b102f03154b0"
+  dependencies:
+    es6-error "^4.1.1"
+    hoist-non-react-statics "^2.5.4"
+    invariant "^2.2.4"
+    is-promise "^2.1.0"
+    lodash "^4.17.10"
+    lodash-es "^4.17.10"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
 
 redux-persist-transform-filter@0.0.18:
   version "0.0.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,77 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.42.tgz#352e40c92e0460d3e82f49bd7e79f6cda76f919f"
+  dependencies:
+    core-js "^2.5.3"
+    regenerator-runtime "^0.11.1"
+
+"@babel/runtime@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.56.tgz#cda612dffd5b1719a7b8e91e3040bd6ae64de8b0"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
+"@material-ui/core@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-1.5.0.tgz#00884bb4139d98786d05a97803d19426d4afa55d"
+  dependencies:
+    "@babel/runtime" "7.0.0-beta.42"
+    "@types/jss" "^9.5.3"
+    "@types/react-transition-group" "^2.0.8"
+    brcast "^3.0.1"
+    classnames "^2.2.5"
+    csstype "^2.5.2"
+    debounce "^1.1.0"
+    deepmerge "^2.0.1"
+    dom-helpers "^3.2.1"
+    hoist-non-react-statics "^2.5.0"
+    is-plain-object "^2.0.4"
+    jss "^9.3.3"
+    jss-camel-case "^6.0.0"
+    jss-default-unit "^8.0.2"
+    jss-global "^3.0.0"
+    jss-nested "^6.0.1"
+    jss-props-sort "^6.0.0"
+    jss-vendor-prefixer "^7.0.0"
+    keycode "^2.1.9"
+    normalize-scroll-left "^0.1.2"
+    popper.js "^1.14.1"
+    prop-types "^15.6.0"
+    react-event-listener "^0.6.2"
+    react-jss "^8.1.0"
+    react-transition-group "^2.2.1"
+    recompose "^0.28.0"
+    warning "^4.0.1"
+
+"@types/jss@^9.5.3":
+  version "9.5.4"
+  resolved "https://registry.yarnpkg.com/@types/jss/-/jss-9.5.4.tgz#89a4ee32a14a8d2937187b1a7f443750e964a74d"
+  dependencies:
+    csstype "^2.0.0"
+    indefinite-observable "^1.0.1"
+
+"@types/prop-types@*":
+  version "15.5.5"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.5.tgz#17038dd322c2325f5da650a94d5f9974943625e3"
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-transition-group@^2.0.8":
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.0.13.tgz#7769fb61eb71d64d087a713956f086a42c3ee171"
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "16.4.10"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.10.tgz#fb577091034b25a81f829923e7d38258f43e3165"
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -173,13 +244,6 @@ aria-query@^0.7.0:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
 
-aria-query@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
-  dependencies:
-    ast-types-flow "0.0.7"
-    commander "^2.11.0"
-
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -285,7 +349,7 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
-ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
+ast-types-flow@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
 
@@ -344,12 +408,6 @@ aws4@^1.6.0:
 axobject-query@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
-  dependencies:
-    ast-types-flow "0.0.7"
-
-axobject-query@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.1.tgz#05dfa705ada8ad9db993fa6896f22d395b0b0a07"
   dependencies:
     ast-types-flow "0.0.7"
 
@@ -1135,6 +1193,10 @@ braces@^2.3.0, braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+brcast@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/brcast/-/brcast-3.0.1.tgz#6256a8349b20de9eed44257a9b24d71493cd48dd"
+
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
@@ -1368,6 +1430,10 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+change-emitter@^0.1.2:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
+
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
@@ -1440,7 +1506,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.3:
+classnames@^2.2.3, classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
 
@@ -1667,7 +1733,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.3:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
@@ -1789,6 +1855,12 @@ css-selector-tokenizer@^0.7.0:
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
 
+css-vendor@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-0.3.8.tgz#6421cfd3034ce664fe7673972fd0119fc28941fa"
+  dependencies:
+    is-in-browser "^1.0.2"
+
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
@@ -1851,6 +1923,10 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
+csstype@^2.0.0, csstype@^2.2.0, csstype@^2.5.2:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.6.tgz#2ae1db2319642d8b80a668d2d025c6196071e788"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -1863,7 +1939,7 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
-damerau-levenshtein@^1.0.0, damerau-levenshtein@^1.0.4:
+damerau-levenshtein@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
 
@@ -1876,6 +1952,10 @@ dashdash@^1.12.0:
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
+
+debounce@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
 
 debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
@@ -1908,6 +1988,10 @@ deep-extend@^0.6.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+deepmerge@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.1.tgz#e862b4e45ea0555072bf51e7fd0d9845170ae768"
 
 default-require-extensions@^2.0.0:
   version "2.0.0"
@@ -2064,7 +2148,7 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-dom-helpers@^3.3.1:
+dom-helpers@^3.2.1, dom-helpers@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
@@ -2161,7 +2245,7 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-emoji-regex@^6.1.0, emoji-regex@^6.5.1:
+emoji-regex@^6.1.0:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
 
@@ -2394,19 +2478,6 @@ eslint-plugin-jsx-a11y@5.1.1:
     damerau-levenshtein "^1.0.0"
     emoji-regex "^6.1.0"
     jsx-ast-utils "^1.4.0"
-
-eslint-plugin-jsx-a11y@6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.1.tgz#7bf56dbe7d47d811d14dbb3ddff644aa656ce8e1"
-  dependencies:
-    aria-query "^3.0.0"
-    array-includes "^3.0.3"
-    ast-types-flow "^0.0.7"
-    axobject-query "^2.0.1"
-    damerau-levenshtein "^1.0.4"
-    emoji-regex "^6.5.1"
-    has "^1.0.3"
-    jsx-ast-utils "^2.0.1"
 
 eslint-plugin-prettier@2.6.2:
   version "2.6.2"
@@ -2792,7 +2863,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.16:
+fbjs@^0.8.1, fbjs@^0.8.16:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -3274,7 +3345,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
@@ -3405,6 +3476,10 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
+hyphenate-style-name@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
+
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -3453,6 +3528,12 @@ import-local@^0.1.1:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+indefinite-observable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/indefinite-observable/-/indefinite-observable-1.0.1.tgz#09915423cc8d6f7eb1cb7882ad134633c9a6edc3"
+  dependencies:
+    symbol-observable "1.0.4"
 
 indent-string@^2.1.0:
   version "2.1.0"
@@ -3660,6 +3741,10 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
+is-function@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -3677,6 +3762,10 @@ is-glob@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
   dependencies:
     is-extglob "^2.1.1"
+
+is-in-browser@^1.0.2, is-in-browser@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
 
 is-installed-globally@^0.1.0:
   version "0.1.0"
@@ -4246,6 +4335,81 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jss-camel-case@^6.0.0, jss-camel-case@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jss-camel-case/-/jss-camel-case-6.1.0.tgz#ccb1ff8d6c701c02a1fed6fb6fb6b7896e11ce44"
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+
+jss-compose@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jss-compose/-/jss-compose-5.0.0.tgz#ce01b2e4521d65c37ea42cf49116e5f7ab596484"
+  dependencies:
+    warning "^3.0.0"
+
+jss-default-unit@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/jss-default-unit/-/jss-default-unit-8.0.2.tgz#cc1e889bae4c0b9419327b314ab1c8e2826890e6"
+
+jss-expand@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/jss-expand/-/jss-expand-5.3.0.tgz#02be076efe650125c842f5bb6fb68786fe441ed6"
+
+jss-extend@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/jss-extend/-/jss-extend-6.2.0.tgz#4af09d0b72fb98ee229970f8ca852fec1ca2a8dc"
+  dependencies:
+    warning "^3.0.0"
+
+jss-global@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jss-global/-/jss-global-3.0.0.tgz#e19e5c91ab2b96353c227e30aa2cbd938cdaafa2"
+
+jss-nested@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/jss-nested/-/jss-nested-6.0.1.tgz#ef992b79d6e8f63d939c4397b9d99b5cbbe824ca"
+  dependencies:
+    warning "^3.0.0"
+
+jss-preset-default@^4.3.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/jss-preset-default/-/jss-preset-default-4.5.0.tgz#d3a457012ccd7a551312014e394c23c4b301cadd"
+  dependencies:
+    jss-camel-case "^6.1.0"
+    jss-compose "^5.0.0"
+    jss-default-unit "^8.0.2"
+    jss-expand "^5.3.0"
+    jss-extend "^6.2.0"
+    jss-global "^3.0.0"
+    jss-nested "^6.0.1"
+    jss-props-sort "^6.0.0"
+    jss-template "^1.0.1"
+    jss-vendor-prefixer "^7.0.0"
+
+jss-props-sort@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/jss-props-sort/-/jss-props-sort-6.0.0.tgz#9105101a3b5071fab61e2d85ea74cc22e9b16323"
+
+jss-template@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jss-template/-/jss-template-1.0.1.tgz#09aed9d86cc547b07f53ef355d7e1777f7da430a"
+  dependencies:
+    warning "^3.0.0"
+
+jss-vendor-prefixer@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz#0166729650015ef19d9f02437c73667231605c71"
+  dependencies:
+    css-vendor "^0.3.8"
+
+jss@^9.3.3, jss@^9.7.0:
+  version "9.8.7"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-9.8.7.tgz#ed9763fc0f2f0260fc8260dac657af61e622ce05"
+  dependencies:
+    is-in-browser "^1.1.3"
+    symbol-observable "^1.1.0"
+    warning "^3.0.0"
+
 jsx-ast-utils@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
@@ -4259,6 +4423,10 @@ jsx-ast-utils@^2.0.0, jsx-ast-utils@^2.0.1:
 jwt-decode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
+
+keycode@^2.1.9:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
 
 killable@^1.0.0:
   version "1.0.0"
@@ -4869,6 +5037,10 @@ normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
 normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+
+normalize-scroll-left@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz#6b79691ba79eb5fb107fa5edfbdc06b55caee2aa"
 
 normalize-url@^1.4.0:
   version "1.9.1"
@@ -5776,7 +5948,25 @@ react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
 
-react-lifecycles-compat@^3.0.4:
+react-event-listener@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.6.2.tgz#df405e9578be052b77a76e4c3914686637caecff"
+  dependencies:
+    "@babel/runtime" "7.0.0-beta.42"
+    prop-types "^15.6.0"
+    warning "^4.0.1"
+
+react-jss@^8.1.0:
+  version "8.6.1"
+  resolved "https://registry.yarnpkg.com/react-jss/-/react-jss-8.6.1.tgz#a06e2e1d2c4d91b4d11befda865e6c07fbd75252"
+  dependencies:
+    hoist-non-react-statics "^2.5.0"
+    jss "^9.7.0"
+    jss-preset-default "^4.3.0"
+    prop-types "^15.6.0"
+    theming "^1.3.0"
+
+react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
@@ -5870,7 +6060,7 @@ react-scripts@1.1.4:
   optionalDependencies:
     fsevents "^1.1.3"
 
-react-transition-group@^2.3.1:
+react-transition-group@^2.2.1, react-transition-group@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.4.0.tgz#1d9391fabfd82e016f26fabd1eec329dbd922b5a"
   dependencies:
@@ -5961,6 +6151,17 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
+recompose@^0.28.0:
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.28.2.tgz#19e679227bdf979e0d31b73ffe7ae38c9194f4a7"
+  dependencies:
+    "@babel/runtime" "7.0.0-beta.56"
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    react-lifecycles-compat "^3.0.2"
+    symbol-observable "^1.0.4"
+
 recursive-readdir@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.1.tgz#90ef231d0778c5ce093c9a48d74e5c5422d13a99"
@@ -6027,9 +6228,13 @@ regenerate@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -6799,7 +7004,11 @@ sw-toolbox@^3.4.0:
     path-to-regexp "^1.0.1"
     serviceworker-cache-polyfill "^4.0.0"
 
-symbol-observable@^1.2.0:
+symbol-observable@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+
+symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
@@ -6864,6 +7073,15 @@ test-exclude@^4.2.1:
 text-table@0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+theming@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/theming/-/theming-1.3.0.tgz#286d5bae80be890d0adc645e5ca0498723725bdc"
+  dependencies:
+    brcast "^3.0.1"
+    is-function "^1.0.1"
+    is-plain-object "^2.0.1"
+    prop-types "^15.5.8"
 
 throat@^3.0.0:
   version "3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@7.0.0", "@babel/runtime@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/runtime@7.0.0-beta.42":
   version "7.0.0-beta.42"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.42.tgz#352e40c92e0460d3e82f49bd7e79f6cda76f919f"
@@ -9,17 +15,11 @@
     core-js "^2.5.3"
     regenerator-runtime "^0.11.1"
 
-"@babel/runtime@7.0.0-beta.56":
-  version "7.0.0-beta.56"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.56.tgz#cda612dffd5b1719a7b8e91e3040bd6ae64de8b0"
+"@material-ui/core@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.0.1.tgz#e8476394a42d89ae404355ddbc093db4d044b225"
   dependencies:
-    regenerator-runtime "^0.12.0"
-
-"@material-ui/core@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-1.5.0.tgz#00884bb4139d98786d05a97803d19426d4afa55d"
-  dependencies:
-    "@babel/runtime" "7.0.0-beta.42"
+    "@babel/runtime" "7.0.0"
     "@types/jss" "^9.5.3"
     "@types/react-transition-group" "^2.0.8"
     brcast "^3.0.1"
@@ -44,7 +44,7 @@
     react-event-listener "^0.6.2"
     react-jss "^8.1.0"
     react-transition-group "^2.2.1"
-    recompose "^0.28.0"
+    recompose "^0.29.0"
     warning "^4.0.1"
 
 "@types/jss@^9.5.3":
@@ -6379,11 +6379,11 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-recompose@^0.28.0:
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.28.2.tgz#19e679227bdf979e0d31b73ffe7ae38c9194f4a7"
+recompose@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.29.0.tgz#f1a4e20d5f24d6ef1440f83924e821de0b1bccef"
   dependencies:
-    "@babel/runtime" "7.0.0-beta.56"
+    "@babel/runtime" "^7.0.0"
     change-emitter "^0.1.2"
     fbjs "^0.8.1"
     hoist-non-react-statics "^2.3.1"


### PR DESCRIPTION
I refactored the existing Mentor Registration to use [Material UI](https://material-ui.com/) (for shiny components) and [redux-form](https://redux-form.com/7.4.2/) (for easier form management and validation). Then I added Mentee Registration. It seems like we don't have the fields nailed down yet- the models, existing code and mockups are all a little different.

Note that these forms are not hooked up- there are no api endpoints for them yet.

Mentee Registration:
<img width="626" alt="screen shot 2018-09-02 at 6 06 13 pm" src="https://user-images.githubusercontent.com/7531241/44962945-60ce3e00-aedb-11e8-972b-5dfd8c2c863a.png">

Mentor Registration (it looks the same as above, but has an extra Capacity field):
<img width="616" alt="screen shot 2018-09-02 at 6 05 53 pm" src="https://user-images.githubusercontent.com/7531241/44962949-66c41f00-aedb-11e8-8040-1708e21871bb.png">
