### PR TITLE
Correlated Registration Page to Mock ups with @material-ui

### DIFF
--- a/src/Main/Register/Registration.js
+++ b/src/Main/Register/Registration.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { Field } from 'redux-form';
 import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
-
+import RadioGroup from '../forms/RadioGroup';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import TextField from '../forms/TextField';
 import SelectField from '../forms/SelectField';
 
@@ -25,6 +26,9 @@ const interests = [
   { label: 'Career Growth', value: 'careerGrowth' },
 ];
 
+const renderError = ({ meta: { touched, error } }) =>
+  touched && error ? <span>{error}</span> : false;
+
 export const Registration = ({ handleSubmit, classes, isMentor }) => {
   return (
     <div className={classes.form}>
@@ -35,7 +39,7 @@ export const Registration = ({ handleSubmit, classes, isMentor }) => {
           <Field name="firstname" label="First Name" component={TextField} />
           <Field name="lastname" label="Last Name" component={TextField} />
           <Field name="username" label="Username" component={TextField} required />
-          <Field name="email" label="Email" component={TextField} required />
+          <Field name="email" label="E-mail" component={TextField} required />
           <Field name="password" label="Password" type="password" component={TextField} required />
           <Field
             name="confirmPassword"
@@ -49,6 +53,15 @@ export const Registration = ({ handleSubmit, classes, isMentor }) => {
         <label htmlFor="xinfo">Social Media & Info</label>
         <section id="xinfo">
           <Field name="bio" label="Bio" multiline rows="8" component={TextField} />
+          <Field name="goals" label="Goals" multiline rows="5" component={TextField}/>
+          <p></p>
+          <Field name="yearsOfExperience" label="Years of Industry Experience" component={RadioGroup} source={[
+            { value: 'entry', label: '0'},
+            { value: 'junior', label: '1-2'},
+            { value: 'intermediate', label: '3-6'},
+            { value: 'senior', label: '7+'}
+          ]}/>
+
           <Field name="slackHandle" label="Slack Handle" component={TextField} />
           <Field name="linkedinURL" label="Linkedin URL" component={TextField} />
           <Field name="codeRepoURL" label="Code Repository URL" component={TextField} />
@@ -62,7 +75,7 @@ export const Registration = ({ handleSubmit, classes, isMentor }) => {
           )}
         </section>
         <br />
-        <label htmlFor="interests">Areas of interest</label>
+        <label htmlFor="interests">Areas of {(isMentor ? 'Expertise' : 'Interests')}</label>
         <section id="interests">
           <Field
             name="interests"

--- a/src/Main/forms/RadioGroup.js
+++ b/src/Main/forms/RadioGroup.js
@@ -1,0 +1,76 @@
+import { withStyles } from '@material-ui/core/styles';
+import FormControl from '@material-ui/core/FormControl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormLabel from '@material-ui/core/FormLabel';
+import PropTypes from 'prop-types';
+import Radio from '@material-ui/core/Radio';
+import RadioButtonGroup from '@material-ui/core/RadioGroup';
+import React from 'react';
+
+const styles = theme => ({
+  root: {
+    marginTop: 25,
+    display: "flex",
+  },
+  formLabel: {
+    marginBottom: 5,
+    display: "flex",
+    float: "left",
+
+  },
+  labelRadio: {
+    height: 30,
+    display: "flex",
+    float: "left",
+    margin: `${theme.spacing.unit*6}px 15`,
+  },
+  groupRow: {
+    flexDirection: 'row',
+    float: "left",
+  },
+});
+
+export const RadioGroup = ({
+  label,
+  source,
+  disabled,
+  row,
+  classes,
+  // redux-form props
+  input,
+}) => (
+  <FormControl className={classes.root}>
+    <FormLabel className={classes.formLabel}>{label}</FormLabel>
+    <RadioButtonGroup
+      // className={(row && classes.groupRow) || null}
+      className={classes.groupRow}
+      {...input}
+      value={input.value + ''}
+    >
+      {source.map((el, i) => (
+        <FormControlLabel
+          key={i}
+          className={classes.labelRadio}
+          value={el.value}
+          label={el.label}
+          disabled={disabled}
+          control={<Radio color="primary" />}
+        />
+      ))}
+    </RadioButtonGroup>
+  </FormControl>
+);
+
+RadioGroup.displayName = 'RadioGroup';
+
+RadioGroup.propTypes = {
+  label: PropTypes.string,
+  source: PropTypes.array.isRequired,
+  disabled: PropTypes.bool,
+  row: PropTypes.bool,
+  classes: PropTypes.object,
+  // redux-form props
+  input: PropTypes.object,
+};
+
+export default withStyles(styles, { name: 'RadioGroup' })(RadioGroup);

--- a/src/Main/forms/TextField.js
+++ b/src/Main/forms/TextField.js
@@ -2,9 +2,31 @@ import { TextField as MuiTextField } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import React from 'react';
 
-const styles = {
-  width: {},
-};
+const styles = theme => ({
+  textBoxRoot:{
+    padding: 0,
+    'label + &': {
+      marginTop: theme.spacing.unit * 3,
+    },
+  },
+  textBox:{
+    borderRadius: 4,
+    backgroundColor: theme.palette.common.white,
+    border: '1px solid #ced4da',
+    fontSize: 16,
+    padding: '10px 12px',
+    width: 'calc(100% - 24px)',
+    transition: theme.transitions.create(['border-color', 'box-shadow']),
+    '&:focus': {
+      borderColor: '#507BFC',
+      boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
+    },
+  },
+  bootstrapFormLabel: {
+    fontSize: 18,
+  },
+
+});
 
 export const TextField = ({ input, classes, meta: { touched, error }, ...rest }) => (
   <MuiTextField
@@ -14,7 +36,18 @@ export const TextField = ({ input, classes, meta: { touched, error }, ...rest })
     margin="normal"
     {...rest}
     fullWidth
-    className={classes.width}
+    InputProps={{
+      disableUnderline: true,
+      classes:{
+        root: classes.textBoxRoot,
+        input: classes.textBox,
+      },
+    }}
+    InputLabelProps={{
+          shrink: true,
+          className: classes.bootstrapFormLabel,
+        }}
+
   />
 );
 


### PR DESCRIPTION
Registration.js
-Created Radio buttons that are on par with mock ups
-Changed TextFields to be boxes that highlight with mock up color
-Areas of Expertise changes with Mentor or Mentee Page (Areas of Interest)
Added RadioGroup.js to forms