### PR TITLE
Add api for creating a user (User, Profile, Mentor, Mentee)

### DIFF
--- a/mentorship_api/serializers.py
+++ b/mentorship_api/serializers.py
@@ -5,6 +5,9 @@ from mentorship_profile.models import Profile, Mentor, Mentee
 
 
 class MentorSerializer(serializers.ModelSerializer):
+    areas_of_interest = serializers.ListField()
+    mentee_capacity = serializers.IntegerField(max_value=5, min_value=1)
+
     class Meta:
         model = Mentor
         fields = ("id", "mentor_status", "areas_of_interest",
@@ -15,12 +18,20 @@ class MentorSerializer(serializers.ModelSerializer):
 
 
 class MenteeSerializer(serializers.ModelSerializer):
+    area_of_interest = serializers.CharField()
+    goals = serializers.CharField()
+
     class Meta:
         model = Mentee
         fields = ("id", "area_of_interest", "goals")
 
 
 class ProfileSerializer(serializers.ModelSerializer):
+    slack_handle = serializers.CharField(required=False)
+    linked_in_url = serializers.URLField(required=False)
+    projects_url = serializers.URLField(required=False)
+    bio = serializers.CharField(required=True)
+
     class Meta:
         model = Profile
         fields = ("id", "slack_handle", "linked_in_url", "projects_url", "bio",
@@ -28,6 +39,10 @@ class ProfileSerializer(serializers.ModelSerializer):
 
 
 class UserSerializer(serializers.ModelSerializer):
+    email = serializers.EmailField()
+    first_name = serializers.CharField()
+    last_name = serializers.CharField()
+
     class Meta:
         model = User
         fields = ("id", "username", "email", "first_name", "last_name")

--- a/mentorship_api/tests/test_CreateProfile.py
+++ b/mentorship_api/tests/test_CreateProfile.py
@@ -1,0 +1,67 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+
+class CreateProfile(APITestCase):
+    def test_create_profile(self):
+        url = reverse("user_api")
+        new_user = {
+            "user": {
+                "username": "api-tester-create",
+                "email": "test-create@test.test",
+                "first_name": "Johnny",
+                "last_name": "O'Donnell",
+            },
+            "profile": {
+                "slack_handle": "johnnyodonnell",
+                "linked_in_url": "https://linkedin.com/reidhoffman",
+                "projects_url": "https://github.com/johnnyodonnell",
+                "bio": "I am a test profile",
+                "years_industry_experience": "1-3",
+                "email_confirmed": True,
+            },
+            "mentor": {
+                "mentor_status": "approved",
+                "areas_of_interest": ["career_growth"],
+                "mentee_capacity": 3,
+                "currently_accepting_mentees": False,
+            },
+            "mentee": {
+                "area_of_interest": "career_growth",
+                "goals": "increase our test converage",
+            },
+        }
+        response = self.client.post(url, new_user, format="json")
+        data = response.data
+        self.assertIn("user_id", data)
+        self.assertIn("profile_id", data)
+        self.assertIn("mentor_id", data)
+        self.assertIn("mentee_id", data)
+
+    def test_create_profile_errors(self):
+        url = reverse("user_api")
+        new_user = {
+            "user": {
+            },
+            "profile": {
+            },
+            "mentor": {
+            },
+            "mentee": {
+            },
+        }
+        response = self.client.post(url, new_user, format="json")
+        data = response.data
+        self.assertIn("user", data)
+        self.assertIn("username", data["user"])
+        self.assertIn("first_name", data["user"])
+        self.assertIn("last_name", data["user"])
+        self.assertIn("email", data["user"])
+        self.assertIn("profile", data)
+        self.assertIn("bio", data["profile"])
+        self.assertIn("mentor", data)
+        self.assertIn("areas_of_interest", data["mentor"])
+        self.assertIn("mentee_capacity", data["mentor"])
+        self.assertIn("mentee", data)
+        self.assertIn("area_of_interest", data["mentee"])
+        self.assertIn("goals", data["mentee"])


### PR DESCRIPTION
Adding api for creating a user

This receives data like the following:

```
{  
   'user':{
      'username':'api-tester',
      'email':'test@test.test',
      'first_name':'Johnny',
      'last_name':"O'Donnell"
   },
   'profile':{
      'slack_handle':'johnnyodonnell',
      'linked_in_url':'reidhoffman',
      'projects_url':'github.com/johnnyodonnell',
      'bio':'I am a test profile',
      'years_industry_experience':'1-3',
      'email_confirmed':False
   },
   'mentor':{
      'mentor_status':'approved',
      'areas_of_interest':[  
         'career_growth'
      ],
      'mentee_capacity':3,
      'currently_accepting_mentees':True
   },
   'mentee':{
      'area_of_interest':'career_growth',
      'goals':'increase test coverage'
   }
}
```

and returns:

```
{  
   'user_id': 1,
   'profile_id': 1,
   'mentor_id': 1,
   'mentee_id': 1,
}
```